### PR TITLE
Expose MultiTask API

### DIFF
--- a/ultralytics/multitask/__init__.py
+++ b/ultralytics/multitask/__init__.py
@@ -1,0 +1,17 @@
+# Ultralytics MultiTask 🚀, AGPL-3.0 license
+
+"""Convenience imports for the MultiTask package."""
+
+from .engine.model import TrackNet as MultiTask
+from .tracknet_v4 import TrackNetV4Model as MultiTaskModel
+from .train import TrackNetTrainer as MultiTaskTrainer
+from .val import TrackNetValidator as MultiTaskValidator
+from .predict import TrackNetPredictor as MultiTaskPredictor
+
+__all__ = (
+    'MultiTask',
+    'MultiTaskModel',
+    'MultiTaskTrainer',
+    'MultiTaskValidator',
+    'MultiTaskPredictor',
+)


### PR DESCRIPTION
## Summary
- expose MultiTask-related classes in `ultralytics.multitask`

## Testing
- `pre-commit` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6845a5f542408323a7fdbf3349bd4750