### PR TITLE
Add MultiTask usage doc

### DIFF
--- a/docs/tasks/index.md
+++ b/docs/tasks/index.md
@@ -44,6 +44,12 @@ video frame with high accuracy and speed.
 
 [Pose Examples](pose.md){ .md-button .md-button--primary}
 
+## [MultiTask](multitask.md)
+
+The MultiTask model predicts detection boxes, tracking IDs and pose keypoints simultaneously.
+
+[MultiTask Examples](multitask.md){ .md-button .md-button--primary}
+
 ## Conclusion
 
 YOLOv8 supports multiple tasks, including detection, segmentation, classification, and keypoints detection. Each of

--- a/docs/tasks/multitask.md
+++ b/docs/tasks/multitask.md
@@ -1,0 +1,41 @@
+---
+comments: true
+description: Learn how to train and run inference with the YOLOv8 MultiTask model that outputs detections, tracking IDs and pose keypoints.
+keywords: YOLOv8, MultiTask, track, pose, training, inference
+---
+
+# MultiTask
+
+The **MultiTask** model combines object detection, tracking and pose estimation in a single network. To enable these features, set the configuration keys `track` and `pose` to `True` when training or running inference.
+
+## Train
+
+Use the `yolo` command to train the model with both tracking and pose heads enabled:
+
+```bash
+yolo train model=ultralytics/models/v8/multitask.yaml data=your_data.yaml \
+    epochs=100 imgsz=640 track=True pose=True
+```
+
+The same can be achieved from Python:
+
+```python
+from ultralytics import YOLO
+
+model = YOLO('ultralytics/models/v8/multitask.yaml')
+model.train(data='your_data.yaml', epochs=100, imgsz=640, track=True, pose=True)
+```
+
+## Inference
+
+After training, run prediction on images:
+
+```bash
+yolo predict model=path/to/best.pt source=path/to/image.jpg track=True pose=True
+```
+
+Or perform tracking on video streams:
+
+```bash
+yolo track model=path/to/best.pt source=path/to/video.mp4 track=True pose=True
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -144,6 +144,7 @@ nav:
           - Segment: tasks/segment.md
           - Classify: tasks/classify.md
           - Pose: tasks/pose.md
+          - MultiTask: tasks/multitask.md
   - Quickstart: quickstart.md
   - Modes:
       - modes/index.md
@@ -159,6 +160,7 @@ nav:
       - Segment: tasks/segment.md
       - Classify: tasks/classify.md
       - Pose: tasks/pose.md
+      - MultiTask: tasks/multitask.md
   - Models:
       - models/index.md
       - YOLOv3: models/yolov3.md


### PR DESCRIPTION
## Summary
- document how to train and run inference for the MultiTask model
- link the new doc in the site navigation
- mention MultiTask in the tasks index

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6845a5f5d0648323a485f3ffae6b16f1