### PR TITLE
Add multitask training entry script

### DIFF
--- a/multitask.py
+++ b/multitask.py
@@ -1,0 +1,54 @@
+import argparse
+
+from ultralytics.multitask.train import MultiTaskTrainer
+
+
+def main(arg):
+    """Entry point for training the MultiTask model."""
+
+    overrides = {}
+    overrides['model'] = arg.model_path
+    overrides['mode'] = arg.mode
+    overrides['data'] = arg.data
+    overrides['epochs'] = arg.epochs
+    overrides['plots'] = arg.plots
+    overrides['batch'] = arg.batch
+    overrides['patience'] = 300
+    overrides['mosaic'] = 0.0
+    overrides['plots'] = arg.plots
+    overrides['val'] = arg.val
+    overrides['use_dxdy_loss'] = arg.use_dxdy_loss
+    overrides['use_resampler'] = arg.use_resampler
+    overrides['save_period'] = 10
+
+    if arg.mode == 'train':
+        trainer = MultiTaskTrainer(overrides=overrides)
+        trainer.train()
+    else:
+        raise ValueError(f"Unsupported mode: {arg.mode}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Train a custom MultiTask model with overrides.")
+
+    parser.add_argument('--model_path', type=str,
+                        default='ultralytics/models/v8/multitask.yaml',
+                        help='Path to the model')
+    parser.add_argument('--mode', type=str, default='train',
+                        help='Mode for the training (e.g., train)')
+    parser.add_argument('--data', type=str, default='multitask.yaml',
+                        help='Data configuration (e.g., multitask.yaml)')
+    parser.add_argument('--epochs', type=int, default=2,
+                        help='Number of epochs')
+    parser.add_argument('--plots', type=bool, default=False,
+                        help='Whether to plot or not')
+    parser.add_argument('--batch', type=int, default=16, help='Batch size')
+    parser.add_argument('--val', type=bool, default=True, help='Run validation')
+    parser.add_argument('--use_dxdy_loss', type=bool, default=True,
+                        help='Use dxdy loss or not')
+    parser.add_argument('--use_resampler', type=bool, default=True,
+                        help='Use resampler on each epoch')
+
+    args = parser.parse_args()
+    main(args)

--- a/ultralytics/multitask/README.md
+++ b/ultralytics/multitask/README.md
@@ -31,9 +31,7 @@ docker run --gpus all --ipc=host \
 -v /hdd/dataset/tracknetv4/val_confusion_matrix:/usr/src/datasets/tracknet/val_confusion_matrix \
 -it tracknetv4
 
-python tracknet.py --mode train_v2 --model_path /usr/src/ultralytics/ultralytics/models/v8/tracknetv4.yaml --epoch 200
-
-python tracknet.py --mode val_v2 --batch 1 --model_path /usr/src/ultralytics/runs/detect/train345/weights/last.pt --source /usr/src/datasets/tracknet/val_data
+python multitask.py --mode train --model_path /usr/src/ultralytics/ultralytics/models/v8/multitask.yaml --epochs 200
 ```
 
 ## TODO


### PR DESCRIPTION
## Summary
- add `multitask.py` for multitask training using `MultiTaskTrainer`
- update README usage docs for running `multitask.py`

## Testing
- `python -m py_compile multitask.py`
- `python multitask.py --help` *(fails: ModuleNotFoundError: No module named 'requests')*


------
https://chatgpt.com/codex/tasks/task_e_68482a28bb4c8323b88cf4a8d52a9e39