### PR TITLE
Clean up unused imports

### DIFF
--- a/ultralytics/multitask/configurable_dataset.py
+++ b/ultralytics/multitask/configurable_dataset.py
@@ -6,10 +6,8 @@ from torch.utils.data import Dataset
 import cv2
 import hashlib
 import os
-import pandas as pd
 import numpy as np
 from torchvision import transforms
-import torch.nn.functional as F
 from tqdm import tqdm
 from functools import lru_cache
 from glob import glob

--- a/ultralytics/multitask/val_dataset.py
+++ b/ultralytics/multitask/val_dataset.py
@@ -6,10 +6,8 @@ from torch.utils.data import Dataset
 import cv2
 import hashlib
 import os
-import pandas as pd
 import numpy as np
 from torchvision import transforms
-import torch.nn.functional as F
 from tqdm import tqdm
 from functools import lru_cache
 from glob import glob


### PR DESCRIPTION
## Summary
- remove unused pandas and torch.nn.functional imports from dataset modules

## Testing
- `python -m py_compile ultralytics/multitask/configurable_dataset.py ultralytics/multitask/val_dataset.py`

------
https://chatgpt.com/codex/tasks/task_e_6849236d42948323aa848ab0738456d6