### PR TITLE
Update multitask export aliases

### DIFF
--- a/ultralytics/multitask/__init__.py
+++ b/ultralytics/multitask/__init__.py
@@ -4,14 +4,15 @@
 
 from .engine.model import TrackNet as MultiTask
 from .multitask import MultiTaskModel
-from .train import TrackNetTrainer as MultiTaskTrainer
+from .train import MultiTaskTrainer, TrackNetTrainer
 from .val import MultiTaskValidator
-from .predict import TrackNetPredictor as MultiTaskPredictor
+from .predict import MultiTaskPredictor
 
 __all__ = (
     'MultiTask',
     'MultiTaskModel',
     'MultiTaskTrainer',
+    'TrackNetTrainer',
     'MultiTaskValidator',
     'MultiTaskPredictor',
 )


### PR DESCRIPTION
## Summary
- update imports and exports in multitask package
- expose TrackNetTrainer alongside MultiTaskTrainer

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6849569b893083239b5bd91e6d0bc9cf