### PR TITLE
Support png and jpg frame inputs

### DIFF
--- a/ultralytics/multitask/README.md
+++ b/ultralytics/multitask/README.md
@@ -16,12 +16,16 @@ Each match directory under the dataset root should include at least:
 ```
 match_x/
 ├── annotation.json        # frame annotations
-├── frame/                 # extracted PNG frames
-│   ├── 000001.png
+├── frame/                 # extracted image frames (.png or .jpg)
+│   ├── frame_000001.png   # or frame_000001.jpg
 │   └── ...
 ├── csv/                   # ball trajectory CSV files (optional)
 └── video/                 # source videos (optional)
 ```
+
+Frame numbers are extracted from the final underscore-separated field of each
+filename, so `foo_bar_000123.png` and `foo_bar_000123.jpg` both correspond to
+frame `123`.
 
 The number of frames loaded from each `match_x` folder can be limited by
 adjusting the optional `path_counts` dictionary in


### PR DESCRIPTION
## Summary
- allow dataset loaders to read `.png` and `.jpg` frames
- look up frame metadata using last underscore-separated value
- document allowed frame extensions in README

## Testing
- `python -m py_compile ultralytics/multitask/dataset.py ultralytics/multitask/val_dataset.py ultralytics/multitask/configurable_dataset.py`

------
https://chatgpt.com/codex/tasks/task_e_684988fde9fc832385f96279380d3cc3