### PR TITLE
Implement collate_fn for multitask datasets

### DIFF
--- a/ultralytics/multitask/README.md
+++ b/ultralytics/multitask/README.md
@@ -31,6 +31,9 @@ The number of frames loaded from each `match_x` folder can be limited by
 adjusting the optional `path_counts` dictionary in
 `MultiTaskConfigurableDataset`.
 
+MultiTask dataset classes also define a `collate_fn` so `build_dataloader`
+automatically stacks images and concatenates detection targets.
+
 ## how to build
 ULTRALYTICS_BRANCH: 指定使用分之
 CACHE_BUSTER: 確保每次都能拉取最新的分支

--- a/ultralytics/multitask/configurable_dataset.py
+++ b/ultralytics/multitask/configurable_dataset.py
@@ -518,3 +518,23 @@ class MultiTaskConfigurableDataset(Dataset):
             "batch_idx": batch_idx,
             "img_files": sample["img_paths"],
         }
+
+    @staticmethod
+    def collate_fn(batch):
+        """Collate function that stacks images and concatenates annotations."""
+        new_batch = {}
+        keys = batch[0].keys()
+        values = list(zip(*[list(b.values()) for b in batch]))
+        for i, k in enumerate(keys):
+            value = values[i]
+            if k in ["img", "target"]:
+                value = torch.stack(value, 0)
+            elif k in ["bboxes", "keypoints", "cls"]:
+                value = torch.cat(value, 0)
+            new_batch[k] = value
+        if "batch_idx" in new_batch:
+            new_batch["batch_idx"] = list(new_batch["batch_idx"])
+            for i in range(len(new_batch["batch_idx"])):
+                new_batch["batch_idx"][i] += i
+            new_batch["batch_idx"] = torch.cat(new_batch["batch_idx"], 0)
+        return new_batch

--- a/ultralytics/multitask/dataset.py
+++ b/ultralytics/multitask/dataset.py
@@ -481,3 +481,23 @@ class MultiTaskDataset(Dataset):
             "batch_idx": batch_idx,
             "img_files": sample["img_paths"],
         }
+
+    @staticmethod
+    def collate_fn(batch):
+        """Collate function that stacks images and concatenates annotations."""
+        new_batch = {}
+        keys = batch[0].keys()
+        values = list(zip(*[list(b.values()) for b in batch]))
+        for i, k in enumerate(keys):
+            value = values[i]
+            if k in ["img", "target"]:
+                value = torch.stack(value, 0)
+            elif k in ["bboxes", "keypoints", "cls"]:
+                value = torch.cat(value, 0)
+            new_batch[k] = value
+        if "batch_idx" in new_batch:
+            new_batch["batch_idx"] = list(new_batch["batch_idx"])
+            for i in range(len(new_batch["batch_idx"])):
+                new_batch["batch_idx"][i] += i
+            new_batch["batch_idx"] = torch.cat(new_batch["batch_idx"], 0)
+        return new_batch

--- a/ultralytics/multitask/val_dataset.py
+++ b/ultralytics/multitask/val_dataset.py
@@ -443,3 +443,23 @@ class MultiTaskValDataset(Dataset):
             "batch_idx": batch_idx,
             "img_files": sample["img_paths"],
         }
+
+    @staticmethod
+    def collate_fn(batch):
+        """Collate function that stacks images and concatenates annotations."""
+        new_batch = {}
+        keys = batch[0].keys()
+        values = list(zip(*[list(b.values()) for b in batch]))
+        for i, k in enumerate(keys):
+            value = values[i]
+            if k in ["img", "target"]:
+                value = torch.stack(value, 0)
+            elif k in ["bboxes", "keypoints", "cls"]:
+                value = torch.cat(value, 0)
+            new_batch[k] = value
+        if "batch_idx" in new_batch:
+            new_batch["batch_idx"] = list(new_batch["batch_idx"])
+            for i in range(len(new_batch["batch_idx"])):
+                new_batch["batch_idx"][i] += i
+            new_batch["batch_idx"] = torch.cat(new_batch["batch_idx"], 0)
+        return new_batch


### PR DESCRIPTION
## Summary
- add dataset-level `collate_fn` for MultiTask datasets
- update docs on dataloader behavior

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_684a7627fb248323a27eb461f8e576b4