### PR TITLE
Fix pose loss size mismatch

### DIFF
--- a/ultralytics/yolo/utils/loss.py
+++ b/ultralytics/yolo/utils/loss.py
@@ -118,6 +118,7 @@ class v8DetectionLoss:
         self.nc = m.nc  # number of classes
         self.no = m.no
         self.reg_max = m.reg_max
+        self.feat_no = getattr(m, 'feat_no', (self.no - self.nc) // self.reg_max)
         self.device = device
 
         self.use_dfl = m.reg_max > 1


### PR DESCRIPTION
## Summary
- fix incorrect feature count in pose loss initialization

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_684ace877e2883238904ff11dfc942db