### PR TITLE
Fix PoseLoss feature split

### DIFF
--- a/ultralytics/yolo/utils/loss.py
+++ b/ultralytics/yolo/utils/loss.py
@@ -330,10 +330,10 @@ class v8PoseLoss(v8DetectionLoss):
         feats, pred_kpts = preds if isinstance(preds[0], list) else preds[1]
         pred_distri_all, pred_scores = torch.cat(
             [xi.view(feats[0].shape[0], self.no, -1) for xi in feats], 2
-        ).split((self.reg_max * self.num_groups, self.nc), 1)
+        ).split((self.reg_max * self.feat_no, self.nc), 1)
         pred_distri, _ = (
-            pred_distri_all.split((self.reg_max * 4, self.reg_max * (self.num_groups - 4)), 1)
-            if self.num_groups > 4
+            pred_distri_all.split((self.reg_max * 4, self.reg_max * (self.feat_no - 4)), 1)
+            if self.feat_no > 4
             else (pred_distri_all, None)
         )
 
@@ -341,6 +341,12 @@ class v8PoseLoss(v8DetectionLoss):
         pred_scores = pred_scores.permute(0, 2, 1).contiguous()
         pred_distri = pred_distri.permute(0, 2, 1).contiguous()
         pred_kpts = pred_kpts.permute(0, 2, 1).contiguous()
+
+        batch_size = pred_scores.shape[0]
+        pred_kpts = pred_kpts.view(batch_size, -1, *self.kpt_shape)
+        if self.num_groups > 1:
+            pred_kpts = pred_kpts.repeat_interleave(self.num_groups, dim=1)
+        pred_kpts = pred_kpts.contiguous()
 
         dtype = pred_scores.dtype
         imgsz = torch.tensor(feats[0].shape[2:], device=self.device, dtype=dtype) * self.stride[0]  # image size (h,w)
@@ -350,7 +356,6 @@ class v8PoseLoss(v8DetectionLoss):
             anchor_points = anchor_points.repeat(self.num_groups, 1)
             stride_tensor = stride_tensor.repeat(self.num_groups, 1)
         # targets
-        batch_size = pred_scores.shape[0]
         batch_idx = batch['batch_idx'].view(-1, 1)
         targets = torch.cat((batch_idx, batch['cls'].view(-1, 1), batch['bboxes']), 1)
         targets = self.preprocess(targets.to(self.device), batch_size, scale_tensor=imgsz[[1, 0, 1, 0]])


### PR DESCRIPTION
## Summary
- fix channel split calculation in Pose loss
- handle grouped anchor decoding for keypoints

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_e_684beb2ae764832387a81df5ee7c8977