### PR TITLE
Fix detection head to aggregate all scales

### DIFF
--- a/ultralytics/multitask/multitask.py
+++ b/ultralytics/multitask/multitask.py
@@ -4,6 +4,7 @@ import torch
 
 from ultralytics.nn.tasks import DetectionModel
 from ultralytics.tracknet.utils.confusion_matrix import ConfConfusionMatrix
+from ultralytics.yolo.utils.tal import make_anchors
 from .utils.multi_task_loss import MultiTaskLoss
 
 
@@ -42,14 +43,19 @@ class MultiTaskModel(DetectionModel):
             x = m(x)
             y.append(x if m.i in self.save else None)
             if m.i == self.detect_idx:
-                outputs[0] = x
-                # propagate anchors and strides to pose head if available
-                pose_head = self.model[self.pose_idx]
-                if hasattr(m, "anchors") and m.anchors.numel():
+                # detection output is first element, feature maps second
+                outputs[0] = x[0] if isinstance(x, tuple) else x
+                feat = x[1] if isinstance(x, tuple) else x
+                # regenerate anchors from current feature shapes
+                if hasattr(m, "stride"):
+                    anchors, strides = (a.transpose(0, 1) for a in make_anchors(feat, m.stride, 0.5))
+                    m.anchors, m.strides = anchors, strides
+                    pose_head = self.model[self.pose_idx]
                     if hasattr(pose_head, "anchors"):
-                        pose_head.anchors = m.anchors
+                        pose_head.anchors = anchors
                     if hasattr(pose_head, "strides"):
-                        pose_head.strides = m.strides
+                        pose_head.strides = strides
+                x = feat
         outputs[1] = x  # pose output is last
         return outputs
 

--- a/ultralytics/nn/modules/head.py
+++ b/ultralytics/nn/modules/head.py
@@ -219,13 +219,19 @@ class Detect(nn.Module):
                               1)
         if self.training:
             return x
+        if self.dynamic or self.shape != shape or not self.anchors.numel():
+            self.anchors, self.strides = (a.transpose(0, 1) for a in make_anchors(x, self.stride, 0.5))
+            self.shape = shape
+
+        x_cat = torch.cat([xi.view(shape[0], self.no, -1) for xi in x], 2)
+        if self.export and self.format in ('saved_model', 'pb', 'tflite', 'edgetpu', 'tfjs'):  # avoid TF FlexSplitV ops
+            box = x_cat[:, :self.reg_max * 4]
+            cls = x_cat[:, self.reg_max * 4:]
         else:
-            x_cat = x[0].view(shape[0], self.no, -1)
-            current_dfl, next_dfl, cls = x_cat.split((self.reg_max * 4, self.reg_max * 4, self.nc), 1)
-            current = self.dfl(current_dfl)
-            next = self.dfl(next_dfl)
-            y = torch.cat((current, next, cls.sigmoid()), 1)
-            return (y, x)
+            box, cls = x_cat.split((self.reg_max * 4, self.nc), 1)
+        dbox = dist2bbox(self.dfl(box), self.anchors.unsqueeze(0), xywh=True, dim=1) * self.strides
+        y = torch.cat((dbox, cls.sigmoid()), 1)
+        return y if self.export else (y, x)
             # feats = x[0].clone()
             # pred_distri, pred_scores = feats.view(self.no, -1).split(
             #     (reg_max * feat_no, nc), 0)
@@ -381,6 +387,15 @@ class Pose(Detect):
         if self.training:
             return x, kpt
         pred_kpt = self.kpts_decode(bs, kpt)
+        if self.num_groups > 1:
+            if self.export:
+                if pred_kpt.shape[-1] != x.shape[-1]:
+                    pred_kpt = pred_kpt.repeat_interleave(self.num_groups, dim=2)
+            else:
+                det, feats = x
+                if pred_kpt.shape[-1] != det.shape[-1]:
+                    pred_kpt = pred_kpt.repeat_interleave(self.num_groups, dim=2)
+                x = (det, feats)
         return torch.cat([x, pred_kpt], 1) if self.export else (torch.cat([x[0], pred_kpt], 1), (x[1], kpt))
 
     def kpts_decode(self, bs, kpts):


### PR DESCRIPTION
## Summary
- recompute anchors when needed and aggregate predictions across all detection scales
- keep anchor propagation logic in `_predict_once`

## Testing
- `flake8` *(fails: command not found)*
- `pytest -k "not slow" -q` *(fails: ModuleNotFoundError: No module named 'requests')*


------
https://chatgpt.com/codex/tasks/task_e_684e49df3b048323afb57222cf838658