### PR TITLE
Fix detection head to aggregate all scales

### DIFF
--- a/ultralytics/multitask/multitask.py
+++ b/ultralytics/multitask/multitask.py
@@ -4,6 +4,7 @@ import torch
 
 from ultralytics.nn.tasks import DetectionModel
 from ultralytics.tracknet.utils.confusion_matrix import ConfConfusionMatrix
+from ultralytics.yolo.utils.tal import make_anchors
 from .utils.multi_task_loss import MultiTaskLoss
 
 
@@ -42,14 +43,19 @@ class MultiTaskModel(DetectionModel):
             x = m(x)
             y.append(x if m.i in self.save else None)
             if m.i == self.detect_idx:
-                outputs[0] = x
-                # propagate anchors and strides to pose head if available
-                pose_head = self.model[self.pose_idx]
-                if hasattr(m, "anchors") and m.anchors.numel():
+                # detection output is first element, feature maps second
+                outputs[0] = x[0] if isinstance(x, tuple) else x
+                feat = x[1] if isinstance(x, tuple) else x
+                # regenerate anchors from current feature shapes
+                if hasattr(m, "stride"):
+                    anchors, strides = (a.transpose(0, 1) for a in make_anchors(feat, m.stride, 0.5))
+                    m.anchors, m.strides = anchors, strides
+                    pose_head = self.model[self.pose_idx]
                     if hasattr(pose_head, "anchors"):
-                        pose_head.anchors = m.anchors
+                        pose_head.anchors = anchors
                     if hasattr(pose_head, "strides"):
-                        pose_head.strides = m.strides
+                        pose_head.strides = strides
+                x = feat
         outputs[1] = x  # pose output is last
         return outputs
 


### PR DESCRIPTION
## Summary
- recompute anchors when needed and aggregate predictions across all detection scales
- keep anchor propagation logic in `_predict_once`
- fix detection box split to use `feat_no`

## Testing
- `flake8` *(fails: command not found)*
- `pytest -k "not slow" -q` *(fails: ModuleNotFoundError: No module named 'requests')*


------
https://chatgpt.com/codex/tasks/task_e_684e49df3b048323afb57222cf838658