### PR TITLE
Fix keypoint decoding for mismatched anchor groups

### DIFF
--- a/ultralytics/multitask/multitask.py
+++ b/ultralytics/multitask/multitask.py
@@ -4,6 +4,7 @@ import torch
 
 from ultralytics.nn.tasks import DetectionModel
 from ultralytics.tracknet.utils.confusion_matrix import ConfConfusionMatrix
+from ultralytics.yolo.utils.tal import make_anchors
 from .utils.multi_task_loss import MultiTaskLoss
 
 
@@ -42,14 +43,27 @@ class MultiTaskModel(DetectionModel):
             x = m(x)
             y.append(x if m.i in self.save else None)
             if m.i == self.detect_idx:
+                # keep both detection predictions and feature maps
                 outputs[0] = x
-                # propagate anchors and strides to pose head if available
-                pose_head = self.model[self.pose_idx]
-                if hasattr(m, "anchors") and m.anchors.numel():
+                feat = x[1] if isinstance(x, tuple) else x
+                # regenerate anchors from current feature shapes
+                if hasattr(m, "stride"):
+                    anchors_det, strides_det = make_anchors(feat, m.stride, 0.5)
+                    # propagate base anchors (without group repetition) to pose head
+                    anchors_pose, strides_pose = anchors_det.transpose(0, 1), strides_det.transpose(0, 1)
+                    # repeat for detection groups only when needed
+                    if getattr(m, "num_groups", 1) > 1:
+                        anchors_det = anchors_det.repeat_interleave(m.num_groups, dim=0)
+                        strides_det = strides_det.repeat_interleave(m.num_groups, dim=0)
+                    m.anchors, m.strides = anchors_det.transpose(0, 1), strides_det.transpose(0, 1)
+                    pose_head = self.model[self.pose_idx]
                     if hasattr(pose_head, "anchors"):
-                        pose_head.anchors = m.anchors
+                        pose_head.anchors = anchors_pose
                     if hasattr(pose_head, "strides"):
-                        pose_head.strides = m.strides
+                        pose_head.strides = strides_pose
+                    if hasattr(pose_head, "shape") and isinstance(feat, list) and feat:
+                        pose_head.shape = feat[0].shape
+                x = feat
         outputs[1] = x  # pose output is last
         return outputs
 

--- a/ultralytics/multitask/val.py
+++ b/ultralytics/multitask/val.py
@@ -1012,7 +1012,12 @@ class MultiTaskValidator(TrackNetValidator):
 
     def preprocess(self, batch):
         batch = super().preprocess(batch)
-        return self.pose_validator.preprocess(batch)
+        batch = self.pose_validator.preprocess(batch)
+        if 'ori_shape' not in batch:
+            imgsz = batch['img'].shape[-2:]
+            batch['ori_shape'] = [imgsz] * len(batch['img'])
+            batch['ratio_pad'] = [(1.0, 1.0)] * len(batch['img'])
+        return batch
 
     def postprocess(self, preds):
         track_pred, pose_pred = preds
@@ -1032,8 +1037,18 @@ class MultiTaskValidator(TrackNetValidator):
 
     def update_metrics(self, preds, batch, loss):
         track_pred, pose_pred = preds
-        super().update_metrics([None, [track_pred]], batch, loss)
-        self.pose_validator.update_metrics(pose_pred, batch)
+        # detection head returns (preds, feats) during training/validation
+        if isinstance(track_pred, tuple):
+            # use raw feature maps for tracking metrics
+            track_pred = track_pred[1]
+        super().update_metrics([None, track_pred], batch, loss)
+        # pose validator expects 1D batch indices
+        if isinstance(batch.get('batch_idx'), torch.Tensor) and batch['batch_idx'].ndim == 2:
+            batch_pose = batch.copy()
+            batch_pose['batch_idx'] = batch['batch_idx'].view(-1)
+        else:
+            batch_pose = batch
+        self.pose_validator.update_metrics(pose_pred, batch_pose)
 
     def finalize_metrics(self):
         super().finalize_metrics()

--- a/ultralytics/nn/modules/head.py
+++ b/ultralytics/nn/modules/head.py
@@ -219,13 +219,29 @@ class Detect(nn.Module):
                               1)
         if self.training:
             return x
+        if self.dynamic or self.shape != shape or not self.anchors.numel():
+            anchor_points, stride_tensor = make_anchors(x, self.stride, 0.5)
+            if self.num_groups > 1:
+                anchor_points = anchor_points.repeat_interleave(self.num_groups, dim=0)
+                stride_tensor = stride_tensor.repeat_interleave(self.num_groups, dim=0)
+            self.anchors, self.strides = anchor_points.transpose(0, 1), stride_tensor.transpose(0, 1)
+            self.shape = shape
+
+        x_cat = torch.cat([xi.view(shape[0], self.no, -1) for xi in x], 2)
+        box_dim = self.reg_max * self.feat_no
+        if self.export and self.format in ('saved_model', 'pb', 'tflite', 'edgetpu', 'tfjs'):
+            box = x_cat[:, :box_dim]
+            cls = x_cat[:, box_dim:]
         else:
-            x_cat = x[0].view(shape[0], self.no, -1)
-            current_dfl, next_dfl, cls = x_cat.split((self.reg_max * 4, self.reg_max * 4, self.nc), 1)
-            current = self.dfl(current_dfl)
-            next = self.dfl(next_dfl)
-            y = torch.cat((current, next, cls.sigmoid()), 1)
-            return (y, x)
+            box, cls = x_cat.split((box_dim, self.nc), 1)
+
+        # first half of box_dim corresponds to current frame, second half to next
+        cur_box, next_box = box.split(box_dim // 2, 1)
+        cur_box = dist2bbox(self.dfl(cur_box), self.anchors.unsqueeze(0), xywh=True, dim=1)
+        next_box = dist2bbox(self.dfl(next_box), self.anchors.unsqueeze(0), xywh=True, dim=1)
+        dbox = torch.cat((cur_box, next_box), 1) * self.strides
+        y = torch.cat((dbox, cls.sigmoid()), 1)
+        return y if self.export else (y, x)
             # feats = x[0].clone()
             # pred_distri, pred_scores = feats.view(self.no, -1).split(
             #     (reg_max * feat_no, nc), 0)
@@ -381,6 +397,15 @@ class Pose(Detect):
         if self.training:
             return x, kpt
         pred_kpt = self.kpts_decode(bs, kpt)
+        if self.num_groups > 1:
+            if self.export:
+                if pred_kpt.shape[-1] != x.shape[-1]:
+                    pred_kpt = pred_kpt.repeat_interleave(self.num_groups, dim=2)
+            else:
+                det, feats = x
+                if pred_kpt.shape[-1] != det.shape[-1]:
+                    pred_kpt = pred_kpt.repeat_interleave(self.num_groups, dim=2)
+                x = (det, feats)
         return torch.cat([x, pred_kpt], 1) if self.export else (torch.cat([x[0], pred_kpt], 1), (x[1], kpt))
 
     def kpts_decode(self, bs, kpts):
@@ -388,7 +413,11 @@ class Pose(Detect):
         ndim = self.kpt_shape[1]
         if self.export:  # required for TFLite export to avoid 'PLACEHOLDER_FOR_GREATER_OP_CODES' bug
             y = kpts.view(bs, *self.kpt_shape, -1)
-            a = (y[:, :, :2] * 2.0 + (self.anchors - 0.5)) * self.strides
+            anchors, strides = self.anchors, self.strides
+            if anchors.numel() and anchors.shape[-1] != y.shape[-1]:
+                g = anchors.shape[-1] // y.shape[-1]
+                anchors, strides = anchors[:, ::g], strides[:, ::g]
+            a = (y[:, :, :2] * 2.0 + (anchors - 0.5)) * strides
             if ndim == 3:
                 a = torch.cat((a, y[:, :, 2:3].sigmoid()), 2)
             return a.view(bs, self.nk, -1)
@@ -396,8 +425,12 @@ class Pose(Detect):
             y = kpts.clone()
             if ndim == 3:
                 y[:, 2::3].sigmoid_()  # inplace sigmoid
-            y[:, 0::ndim] = (y[:, 0::ndim] * 2.0 + (self.anchors[0] - 0.5)) * self.strides
-            y[:, 1::ndim] = (y[:, 1::ndim] * 2.0 + (self.anchors[1] - 0.5)) * self.strides
+            anchors, strides = self.anchors, self.strides
+            if anchors.numel() and anchors.shape[-1] != y.shape[-1]:
+                g = anchors.shape[-1] // y.shape[-1]
+                anchors, strides = anchors[:, ::g], strides[:, ::g]
+            y[:, 0::ndim] = (y[:, 0::ndim] * 2.0 + (anchors[0] - 0.5)) * strides
+            y[:, 1::ndim] = (y[:, 1::ndim] * 2.0 + (anchors[1] - 0.5)) * strides
             return y
 
 


### PR DESCRIPTION
## Summary
- avoid anchor dimension mismatch when multiple prediction groups exist
- slice anchors and strides in `kpts_decode` when their size doesn't match keypoint features
- ensure detection output keeps features for the loss functions
- handle tuple outputs in `MultiTaskValidator.update_metrics`
- pass detection features to metrics rather than postprocessed boxes
- fix pose validator indexing when `batch_idx` is 2D
- set default `ori_shape` and `ratio_pad` in multitask preprocessing

## Testing
- `flake8` *(fails: command not found)*
- `pytest -k "not slow" -q` *(fails to collect tests: ModuleNotFoundError for `requests`)*

------
https://chatgpt.com/codex/tasks/task_e_684e49df3b048323afb57222cf838658