### PR TITLE
Fix anchor device mismatch

### DIFF
--- a/ultralytics/nn/modules/head.py
+++ b/ultralytics/nn/modules/head.py
@@ -56,7 +56,9 @@ class DetectV1(nn.Module):
             cls = x_cat[:, self.reg_max * 4:]
         else:
             box, cls = x_cat.split((self.reg_max * 4, self.nc), 1)
-        dbox = dist2bbox(self.dfl(box), self.anchors.unsqueeze(0), xywh=True, dim=1) * self.strides
+        anchors = self.anchors.to(box.device).unsqueeze(0)
+        strides = self.strides.to(box.device)
+        dbox = dist2bbox(self.dfl(box), anchors, xywh=True, dim=1) * strides
         y = torch.cat((dbox, cls.sigmoid()), 1)
         return y if self.export else (y, x)
 
@@ -237,9 +239,11 @@ class Detect(nn.Module):
 
         # first half of box_dim corresponds to current frame, second half to next
         cur_box, next_box = box.split(box_dim // 2, 1)
-        cur_box = dist2bbox(self.dfl(cur_box), self.anchors.unsqueeze(0), xywh=True, dim=1)
-        next_box = dist2bbox(self.dfl(next_box), self.anchors.unsqueeze(0), xywh=True, dim=1)
-        dbox = torch.cat((cur_box, next_box), 1) * self.strides
+        anchors = self.anchors.to(box.device).unsqueeze(0)
+        strides = self.strides.to(box.device)
+        cur_box = dist2bbox(self.dfl(cur_box), anchors, xywh=True, dim=1)
+        next_box = dist2bbox(self.dfl(next_box), anchors, xywh=True, dim=1)
+        dbox = torch.cat((cur_box, next_box), 1) * strides
         y = torch.cat((dbox, cls.sigmoid()), 1)
         return y if self.export else (y, x)
             # feats = x[0].clone()
@@ -413,7 +417,8 @@ class Pose(Detect):
         ndim = self.kpt_shape[1]
         if self.export:  # required for TFLite export to avoid 'PLACEHOLDER_FOR_GREATER_OP_CODES' bug
             y = kpts.view(bs, *self.kpt_shape, -1)
-            anchors, strides = self.anchors, self.strides
+            anchors = self.anchors.to(y.device)
+            strides = self.strides.to(y.device)
             if anchors.numel() and anchors.shape[-1] != y.shape[-1]:
                 g = anchors.shape[-1] // y.shape[-1]
                 anchors, strides = anchors[:, ::g], strides[:, ::g]
@@ -425,7 +430,8 @@ class Pose(Detect):
             y = kpts.clone()
             if ndim == 3:
                 y[:, 2::3].sigmoid_()  # inplace sigmoid
-            anchors, strides = self.anchors, self.strides
+            anchors = self.anchors.to(y.device)
+            strides = self.strides.to(y.device)
             if anchors.numel() and anchors.shape[-1] != y.shape[-1]:
                 g = anchors.shape[-1] // y.shape[-1]
                 anchors, strides = anchors[:, ::g], strides[:, ::g]


### PR DESCRIPTION
## Summary
- ensure detection anchors reside on the same device as tensors
- move strides to the same device as tensors during forward passes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6850fd5f0624832384a58848d702ad47