### PR TITLE
Fix coordinate reversion in transforms

### DIFF
--- a/ultralytics/multitask/utils/transform.py
+++ b/ultralytics/multitask/utils/transform.py
@@ -115,12 +115,13 @@ def revert_coordinates(data, w=1280, h=720, target_size=640):
 
     # Remove padding
     if h < w:
-        data_reverted[indices, 1] -= pad1
+        data_reverted[indices, 3] -= pad1
+        data_reverted[indices, 5] -= pad1
     else:
-        data_reverted[indices, 0] -= pad1
+        data_reverted[indices, 2] -= pad1
+        data_reverted[indices, 4] -= pad1
 
     # Revert scaling
-    data_reverted[:, 0] /= scale_factor
-    data_reverted[:, 1] /= scale_factor
+    data_reverted[:, 2:6] /= scale_factor
 
     return data_reverted

--- a/ultralytics/tracknet/utils/transform.py
+++ b/ultralytics/tracknet/utils/transform.py
@@ -106,12 +106,13 @@ def revert_coordinates(data, w=1280, h=480, target_size=640):
 
     # Remove padding
     if h < w:
-        data_reverted[indices, 1] -= pad1
+        data_reverted[indices, 3] -= pad1
+        data_reverted[indices, 5] -= pad1
     else:
-        data_reverted[indices, 0] -= pad1
+        data_reverted[indices, 2] -= pad1
+        data_reverted[indices, 4] -= pad1
 
     # Revert scaling
-    data_reverted[:, 0] /= scale_factor
-    data_reverted[:, 1] /= scale_factor
+    data_reverted[:, 2:6] /= scale_factor
 
     return data_reverted


### PR DESCRIPTION
## Summary
- fix padding removal logic for reverting coordinates
- fix scaling reversal to operate on coordinate columns

## Testing
- `flake8` *(fails: command not found)*
- `pytest -q tests` *(fails: ModuleNotFoundError: No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_e_68527a514bf48323af22cd0f9f534bb1