### PR TITLE
Ensure transform_coordinates does not modify inputs

### DIFF
--- a/ultralytics/multitask/configurable_dataset.py
+++ b/ultralytics/multitask/configurable_dataset.py
@@ -290,7 +290,7 @@ class TrackNetConfigurableDataset(Dataset):
         """
         
         # Clone the data to ensure we don't modify the original tensor in-place
-        data_transformed = data
+        data_transformed = data.clone()
         
         # Determine padding
         max_dim = max(w, h)

--- a/ultralytics/multitask/dataset.py
+++ b/ultralytics/multitask/dataset.py
@@ -282,7 +282,7 @@ class TrackNetDataset(Dataset):
         """
         
         # Clone the data to ensure we don't modify the original tensor in-place
-        data_transformed = data
+        data_transformed = data.clone()
         
         # Determine padding
         max_dim = max(w, h)

--- a/ultralytics/multitask/test_dataset.py
+++ b/ultralytics/multitask/test_dataset.py
@@ -157,7 +157,7 @@ class TrackNetTestDataset(Dataset):
         """
         
         # Clone the data to ensure we don't modify the original tensor in-place
-        data_transformed = data
+        data_transformed = data.clone()
         
         # Determine padding
         max_dim = max(w, h)

--- a/ultralytics/multitask/val_dataset.py
+++ b/ultralytics/multitask/val_dataset.py
@@ -231,7 +231,7 @@ class TrackNetValDataset(Dataset):
         """
         
         # Clone the data to ensure we don't modify the original tensor in-place
-        data_transformed = data
+        data_transformed = data.clone()
         
         # Determine padding
         max_dim = max(w, h)

--- a/ultralytics/tracknet/configurable_dataset.py
+++ b/ultralytics/tracknet/configurable_dataset.py
@@ -293,7 +293,7 @@ class TrackNetConfigurableDataset(Dataset):
         """
         
         # Clone the data to ensure we don't modify the original tensor in-place
-        data_transformed = data
+        data_transformed = data.clone()
         
         # Determine padding
         max_dim = max(w, h)

--- a/ultralytics/tracknet/dataset.py
+++ b/ultralytics/tracknet/dataset.py
@@ -272,7 +272,7 @@ class TrackNetDataset(Dataset):
         """
         
         # Clone the data to ensure we don't modify the original tensor in-place
-        data_transformed = data
+        data_transformed = data.clone()
         
         # Determine padding
         max_dim = max(w, h)

--- a/ultralytics/tracknet/test_dataset.py
+++ b/ultralytics/tracknet/test_dataset.py
@@ -157,7 +157,7 @@ class TrackNetTestDataset(Dataset):
         """
         
         # Clone the data to ensure we don't modify the original tensor in-place
-        data_transformed = data
+        data_transformed = data.clone()
         
         # Determine padding
         max_dim = max(w, h)

--- a/ultralytics/tracknet/val_dataset.py
+++ b/ultralytics/tracknet/val_dataset.py
@@ -226,7 +226,7 @@ class TrackNetValDataset(Dataset):
         """
         
         # Clone the data to ensure we don't modify the original tensor in-place
-        data_transformed = data
+        data_transformed = data.clone()
         
         # Determine padding
         max_dim = max(w, h)


### PR DESCRIPTION
## Summary
- clone tensors before modification in all `transform_coordinates` implementations

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6852681a76ac8323aab29cb50ecb8c04