### PR TITLE
Fix mask indexing when saving training samples

### DIFF
--- a/docs/tasks/multitask.md
+++ b/docs/tasks/multitask.md
@@ -14,8 +14,13 @@ Use the `yolo` command to train the model with both tracking and pose heads enab
 
 ```bash
 yolo train model=ultralytics/models/v8/multitask.yaml data=your_data.yaml \
-    epochs=100 imgsz=640 track=True pose=True
+    epochs=100 imgsz=640 track=True pose=True --plots
 ```
+
+The `--plots` flag saves a few annotated training images in the run directory so
+you can verify that ball labels and player keypoints line up correctly. When
+enabled, the trainer also logs the coordinates of each ball and player so you
+can double-check the targets.
 
 The same can be achieved from Python:
 
@@ -23,7 +28,8 @@ The same can be achieved from Python:
 from ultralytics import YOLO
 
 model = YOLO('ultralytics/models/v8/multitask.yaml')
-model.train(data='your_data.yaml', epochs=100, imgsz=640, track=True, pose=True)
+model.train(data='your_data.yaml', epochs=100, imgsz=640, track=True, pose=True,
+            plots=True)
 ```
 
 ## Inference

--- a/ultralytics/multitask/train.py
+++ b/ultralytics/multitask/train.py
@@ -125,7 +125,9 @@ class MultiTaskTrainer(TrackNetTrainer):
                 # Flatten mask to avoid shape mismatch when indexing tensors
                 idx = (batch["batch_idx"] == i).view(-1)
                 boxes = batch["bboxes"][idx] * imgsz
-                kpts = batch["keypoints"][idx] * imgsz
+                kpts = batch["keypoints"][idx].clone()
+                kpts[:, 0::3] *= imgsz
+                kpts[:, 1::3] *= imgsz
                 for j, (box, kpt) in enumerate(zip(boxes, kpts)):
                     xyxy = xywh2xyxy(box.unsqueeze(0))[0].tolist()
                     annotator.box_label(xyxy)

--- a/ultralytics/multitask/train.py
+++ b/ultralytics/multitask/train.py
@@ -131,7 +131,9 @@ class MultiTaskTrainer(TrackNetTrainer):
                 pad = (max_dim - min(w1, h1)) // 2
                 scale_back = max_dim / imgsz
 
-                boxes = batch["bboxes"][idx].clone() * imgsz
+                boxes = batch["bboxes"][idx].clone()
+                boxes[:, 0::2] *= imgsz
+                boxes[:, 1::2] *= imgsz
                 boxes *= scale_back
                 if h1 < w1:
                     boxes[:, 1] -= pad
@@ -153,7 +155,7 @@ class MultiTaskTrainer(TrackNetTrainer):
 
                 for j, (box, kpt) in enumerate(zip(boxes, kpts)):
                     xyxy = xywh2xyxy(box.unsqueeze(0))[0].tolist()
-                    annotator.box_label(xyxy)
+                    annotator.box_label(xyxy, color=(0, 255, 0))
                     annotator.kpts(kpt.view(-1, 3), shape=(h0, w0))
                     LOGGER.info(
                         f"sample {ni}_{i} obj{j} box {xyxy} keypoints {kpt.view(-1, 3).tolist()}"

--- a/ultralytics/multitask/train.py
+++ b/ultralytics/multitask/train.py
@@ -126,32 +126,28 @@ class MultiTaskTrainer(TrackNetTrainer):
                 idx = (batch["batch_idx"] == i).view(-1)
 
                 h0, w0 = annotator.im.shape[:2]
-                w1, h1 = w0 // 2, h0 // 2
-                max_dim = max(w1, h1)
-                pad = (max_dim - min(w1, h1)) // 2
+                max_dim = max(w0, h0)
+                pad = (max_dim - min(w0, h0)) // 2
                 scale_back = max_dim / imgsz
 
                 boxes = batch["bboxes"][idx].clone()
                 boxes[:, 0::2] *= imgsz
                 boxes[:, 1::2] *= imgsz
                 boxes *= scale_back
-                if h1 < w1:
+                if h0 < w0:
                     boxes[:, 1] -= pad
                 else:
                     boxes[:, 0] -= pad
-                boxes *= 2
 
                 kpts = batch["keypoints"][idx].clone()
                 kpts[:, 0::3] *= imgsz
                 kpts[:, 1::3] *= imgsz
                 kpts[:, 0::3] *= scale_back
                 kpts[:, 1::3] *= scale_back
-                if h1 < w1:
+                if h0 < w0:
                     kpts[:, 1::3] -= pad
                 else:
                     kpts[:, 0::3] -= pad
-                kpts[:, 0::3] *= 2
-                kpts[:, 1::3] *= 2
 
                 for j, (box, kpt) in enumerate(zip(boxes, kpts)):
                     xyxy = xywh2xyxy(box.unsqueeze(0))[0].tolist()


### PR DESCRIPTION
## Summary
- document `--plots` saves sample images and logs their coordinates
- move training sample visualization into `MultiTaskTrainer`
- log coordinates while annotating images

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68512d2e8e9c832380a2a76bdeba0cab