### PR TITLE
Fix training sample coordinate scaling

### DIFF
--- a/docs/tasks/multitask.md
+++ b/docs/tasks/multitask.md
@@ -14,8 +14,13 @@ Use the `yolo` command to train the model with both tracking and pose heads enab
 
 ```bash
 yolo train model=ultralytics/models/v8/multitask.yaml data=your_data.yaml \
-    epochs=100 imgsz=640 track=True pose=True
+    epochs=100 imgsz=640 track=True pose=True --plots
 ```
+
+The `--plots` flag saves a few annotated training images in the run directory so
+you can verify that ball labels and player keypoints line up correctly. When
+enabled, the trainer also logs the coordinates of each ball and player so you
+can double-check the targets.
 
 The same can be achieved from Python:
 
@@ -23,7 +28,8 @@ The same can be achieved from Python:
 from ultralytics import YOLO
 
 model = YOLO('ultralytics/models/v8/multitask.yaml')
-model.train(data='your_data.yaml', epochs=100, imgsz=640, track=True, pose=True)
+model.train(data='your_data.yaml', epochs=100, imgsz=640, track=True, pose=True,
+            plots=True)
 ```
 
 ## Inference

--- a/ultralytics/multitask/train.py
+++ b/ultralytics/multitask/train.py
@@ -10,6 +10,8 @@ from ultralytics.tracknet.val_dataset import TrackNetValDataset
 from ultralytics.multitask.configurable_dataset import MultiTaskConfigurableDataset
 from ultralytics.multitask.val_dataset import MultiTaskValDataset
 from ultralytics.yolo.utils import DEFAULT_CFG, LOGGER, RANK
+from ultralytics.yolo.utils.plotting import Annotator
+from ultralytics.yolo.utils.ops import xywh2xyxy
 from ultralytics.yolo.utils.torch_utils import torch_distributed_zero_first
 from ultralytics.yolo.data import build_dataloader
 from ultralytics.yolo.v8.detect.train import DetectionTrainer
@@ -45,9 +47,6 @@ class TrackNetTrainer(DetectionTrainer):
         self.add_callback("print_confusion_matrix", self.tracknet_model.print_confusion_matrix())
         self.add_callback("init_conf_confusion", self.tracknet_model.init_conf_confusion())
         return ("\n" + "%11s" * (3 + len(self.loss_names))) % ("Epoch", "GPU_mem", *self.loss_names, "Size")
-
-    def plot_training_samples(self, batch, ni):
-        pass
 
     def plot_training_labels(self):
         pass
@@ -97,6 +96,69 @@ class MultiTaskTrainer(TrackNetTrainer):
         self.add_callback("print_confusion_matrix", self.model.print_confusion_matrix())
         self.add_callback("init_conf_confusion", self.model.init_conf_confusion())
         return ("\n" + "%11s" * (3 + len(self.loss_names))) % ("Epoch", "GPU_mem", *self.loss_names, "Size")
+
+    def plot_training_samples(self, batch, ni):
+        """Save annotated images and log coordinates during training."""
+        try:
+            import cv2
+        except Exception as e:
+            LOGGER.warning(f"visualization skipped: {e}")
+            return
+
+        dataset = self.train_loader.dataset
+        imgsz = getattr(dataset, "imgsz", 640)
+        batch_size = len(batch["img_files"])
+        for i in range(min(batch_size, 4)):
+            img_path = batch["img_files"][i][-1]
+            img = cv2.imread(str(img_path))
+            if img is None:
+                continue
+
+            annotator = Annotator(img, line_width=2)
+            ball = batch["target"][i, -1]
+            if ball[1] == 1:
+                bx, by = int(ball[2]), int(ball[3])
+                cv2.circle(annotator.im, (bx, by), 5, (0, 0, 255), -1)
+                LOGGER.info(f"sample {ni}_{i} ball ({bx}, {by})")
+
+            if "batch_idx" in batch:
+                # Flatten mask to avoid shape mismatch when indexing tensors
+                idx = (batch["batch_idx"] == i).view(-1)
+
+                h0, w0 = annotator.im.shape[:2]
+                max_dim = max(w0, h0)
+                pad = (max_dim - min(w0, h0)) // 2
+                scale_back = max_dim / imgsz
+
+                boxes = batch["bboxes"][idx].clone()
+                boxes[:, 0::2] *= imgsz
+                boxes[:, 1::2] *= imgsz
+                boxes *= scale_back
+                if h0 < w0:
+                    boxes[:, 1] -= pad
+                else:
+                    boxes[:, 0] -= pad
+
+                kpts = batch["keypoints"][idx].clone()
+                kpts[:, 0::3] *= imgsz
+                kpts[:, 1::3] *= imgsz
+                kpts[:, 0::3] *= scale_back
+                kpts[:, 1::3] *= scale_back
+                if h0 < w0:
+                    kpts[:, 1::3] -= pad
+                else:
+                    kpts[:, 0::3] -= pad
+
+                for j, (box, kpt) in enumerate(zip(boxes, kpts)):
+                    xyxy = xywh2xyxy(box.unsqueeze(0))[0].tolist()
+                    annotator.box_label(xyxy, color=(0, 255, 0))
+                    annotator.kpts(kpt.view(-1, 3), shape=(h0, w0))
+                    LOGGER.info(
+                        f"sample {ni}_{i} obj{j} box {xyxy} keypoints {kpt.view(-1, 3).tolist()}"
+                    )
+
+            fname = self.save_dir / f"train_batch{ni}_{i}.jpg"
+            cv2.imwrite(str(fname), annotator.result())
 
 
 def train(cfg=DEFAULT_CFG, use_python=False):


### PR DESCRIPTION
## Summary
- document `--plots` saving sample images
- move training sample visualization into `MultiTaskTrainer`
- log coordinates while annotating images
- ensure keypoint visibility values remain unchanged when scaling
- restore coordinates back to original image dimensions when saving training samples
- color player bounding boxes
- fix bbox scaling so coordinates recover correctly from letterboxed images

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_e_68512d2e8e9c832380a2a76bdeba0cab