### PR TITLE
Improve visualization scale

### DIFF
--- a/ultralytics/multitask/val.py
+++ b/ultralytics/multitask/val.py
@@ -785,21 +785,22 @@ class TrackNetValidator(BaseValidator):
                     target_xy = (batch_target[frame_idx][2], batch_target[frame_idx][3], batch_target[frame_idx][2], batch_target[frame_idx][3])
 
                 display_predict_image(
-                        batch_img[frame_idx],  
-                        metrics, 
+                        batch_img[frame_idx],
+                        metrics,
                         'val_'+formatted_date+'_'+ str(int(batch_target[frame_idx][0])),
                         box_color=box_color,
                         label=label,
                         save_dir=self.metrics.save_dir,
                         stride = self.stride,
+                        img_size=1280,
                         next=True,
                         loss=loss
-                        ) 
+                        )
             
                 if box_color == 'blue':
                     display_predict_image(
-                        batch_img[frame_idx],  
-                        metrics, 
+                        batch_img[frame_idx],
+                        metrics,
                         'val_'+formatted_date+'_'+ str(int(batch_target[frame_idx][0])),
                         box_color=box_color,
                         label=label,
@@ -807,13 +808,14 @@ class TrackNetValidator(BaseValidator):
                         stride = self.stride,
                         target=target_xy,
                         path='predict_val_FP_img',
+                        img_size=1280,
                         next=False,
                         loss=loss
-                        ) 
+                        )
                 if box_color == 'yellow':
                     display_predict_image(
-                        batch_img[frame_idx],  
-                        metrics, 
+                        batch_img[frame_idx],
+                        metrics,
                         'val_'+formatted_date+'_'+ str(int(batch_target[frame_idx][0])),
                         box_color=box_color,
                         label=label,
@@ -821,19 +823,21 @@ class TrackNetValidator(BaseValidator):
                         stride = self.stride,
                         target=target_xy,
                         path='predict_val_FN_img',
+                        img_size=1280,
                         next=False,
                         loss=loss
-                        ) 
+                        )
 
                 display_predict_image(
-                            batch_img[frame_idx],  
-                            list(self.frame_10_metrics), 
+                            batch_img[frame_idx],
+                            list(self.frame_10_metrics),
                             'val_'+formatted_date+'_'+ str(int(batch_target[frame_idx][0])),
                             box_color=box_color,
                             label=label,
                             save_dir=self.metrics.save_dir,
                             stride = self.stride,
                             path='predict_val_10_frame_img',
+                            img_size=1280,
                             next=False,
                             only_ball=True,
                             loss=loss

--- a/ultralytics/tracknet/utils/plotting.py
+++ b/ultralytics/tracknet/utils/plotting.py
@@ -140,19 +140,29 @@ def display_image_with_coordinates(img_tensor, target, pred, fileName, input_num
     plt.savefig(check_training_img_path+fileName, bbox_inches='tight')
     plt.close()
 
-def display_predict_image(img_tensor, preds, fileName, input_number = None, box_color = 'blue', target = None, label = None, save_dir = Path('.'), stride = 32, path = 'predict_val_img', next = True, only_ball = False, only_next = False, loss = None):
+def display_predict_image(img_tensor, preds, fileName, input_number=None,
+                          box_color='blue', target=None, label=None,
+                          save_dir=Path('.'), stride=32, path='predict_val_img',
+                          next=True, only_ball=False, only_next=False, loss=None,
+                          img_size=640):
     if isinstance(stride, torch.Tensor):
         stride = stride.item()  # 將 tensor 轉換為純數值
     # Convert the image tensor to numpy array
     img_array = img_tensor.cpu().numpy()
+
+    img_height, img_width = img_array.shape[:2]
+    scale_factor = 1.0
+    if img_size and img_width != img_size:
+        scale_factor = img_size / img_width
+        img_array = np.repeat(np.repeat(img_array, int(scale_factor), axis=0),
+                              int(scale_factor), axis=1)
+        img_height, img_width = img_array.shape[:2]
 
     # Create a figure and axes
     fig, ax = plt.subplots(1)
 
     # Display the image
     ax.imshow(img_array, cmap='gray')
-
-    img_height, img_width = img_array.shape[:2]
     lconf, ln_conf = 0, 0
     for pred in preds:
         x_coordinates = pred["grid_x"]
@@ -167,10 +177,11 @@ def display_predict_image(img_tensor, preds, fileName, input_number = None, box_
         # if distance <= 2:
         #     continue
 
-        x_coordinates *= stride
-        y_coordinates *= stride
-        current_x = x_coordinates+x*stride
-        current_y = y_coordinates+y*stride
+        stride_scaled = stride * scale_factor
+        x_coordinates *= stride_scaled
+        y_coordinates *= stride_scaled
+        current_x = x_coordinates + x * stride_scaled
+        current_y = y_coordinates + y * stride_scaled
 
         if isinstance(current_x, torch.Tensor):
             current_x = current_x.cpu().numpy()
@@ -188,8 +199,8 @@ def display_predict_image(img_tensor, preds, fileName, input_number = None, box_
         ln_conf = round(n_conf, 2)
 
         
-        current_nx = x_coordinates+nx*stride
-        current_ny = y_coordinates+ny*stride
+        current_nx = x_coordinates + nx * stride_scaled
+        current_ny = y_coordinates + ny * stride_scaled
 
         if isinstance(current_nx, torch.Tensor):
             current_nx = current_nx.cpu().numpy()
@@ -199,10 +210,15 @@ def display_predict_image(img_tensor, preds, fileName, input_number = None, box_
         # next_x = current_x+dx*640
         # next_y = current_y+dy*640
         if not only_ball:
-            rect = patches.Rectangle(xy=(x_coordinates, y_coordinates), height=stride, width=stride, edgecolor=box_color, facecolor='none', linewidth=0.5)
+            rect = patches.Rectangle(xy=(x_coordinates, y_coordinates),
+                                     height=stride_scaled, width=stride_scaled,
+                                     edgecolor=box_color, facecolor='none', linewidth=0.5)
             ax.add_patch(rect)
         if not only_ball:
-            text = ax.text(x_coordinates+stride+1, y_coordinates+stride, f'{str(conf)}', verticalalignment='bottom', horizontalalignment='left', fontsize=5)
+            text = ax.text(x_coordinates + stride_scaled + 1,
+                           y_coordinates + stride_scaled,
+                           f'{str(conf)}',
+                           verticalalignment='bottom', horizontalalignment='left', fontsize=5)
             text.set_path_effects([patheffects.Stroke(linewidth=2, foreground=(1, 1, 1, 0.3)),
                         patheffects.Normal()])
         
@@ -213,7 +229,9 @@ def display_predict_image(img_tensor, preds, fileName, input_number = None, box_
             if next:
                 ax.scatter(current_nx, current_ny, s=1, c='green', marker='o')
     
-    label_text = ax.text(0, 0, f'{label}, {loss}, conf: {lconf}, n_conf:{ln_conf}', verticalalignment='bottom', horizontalalignment='left', fontsize=5)
+    label_text = ax.text(0, 0,
+                         f'{label}, {loss}, conf: {lconf}, n_conf:{ln_conf}',
+                         verticalalignment='bottom', horizontalalignment='left', fontsize=5)
     label_text.set_path_effects([patheffects.Stroke(linewidth=2, foreground=(1, 1, 1, 0.3)),
                        patheffects.Normal()])
     if target:
@@ -226,6 +244,10 @@ def display_predict_image(img_tensor, preds, fileName, input_number = None, box_
             nx = nx.cpu().item()
         if isinstance(ny, torch.Tensor):
             ny = ny.cpu().item()
+        x *= scale_factor
+        y *= scale_factor
+        nx *= scale_factor
+        ny *= scale_factor
         ax.scatter(x, y, s=1, c='blue', marker='o')
         if x != nx or y != ny:
             ax.scatter(nx, ny, s=1, c='yellow', marker='o')

--- a/ultralytics/tracknet/val.py
+++ b/ultralytics/tracknet/val.py
@@ -780,21 +780,22 @@ class TrackNetValidator(BaseValidator):
                     target_xy = (batch_target[frame_idx][2], batch_target[frame_idx][3], batch_target[frame_idx][2], batch_target[frame_idx][3])
 
                 display_predict_image(
-                        batch_img[frame_idx],  
-                        metrics, 
+                        batch_img[frame_idx],
+                        metrics,
                         'val_'+formatted_date+'_'+ str(int(batch_target[frame_idx][0])),
                         box_color=box_color,
                         label=label,
                         save_dir=self.metrics.save_dir,
                         stride = self.stride,
+                        img_size=1280,
                         next=True,
                         loss=loss
-                        ) 
+                        )
             
                 if box_color == 'blue':
                     display_predict_image(
-                        batch_img[frame_idx],  
-                        metrics, 
+                        batch_img[frame_idx],
+                        metrics,
                         'val_'+formatted_date+'_'+ str(int(batch_target[frame_idx][0])),
                         box_color=box_color,
                         label=label,
@@ -802,13 +803,14 @@ class TrackNetValidator(BaseValidator):
                         stride = self.stride,
                         target=target_xy,
                         path='predict_val_FP_img',
+                        img_size=1280,
                         next=False,
                         loss=loss
-                        ) 
+                        )
                 if box_color == 'yellow':
                     display_predict_image(
-                        batch_img[frame_idx],  
-                        metrics, 
+                        batch_img[frame_idx],
+                        metrics,
                         'val_'+formatted_date+'_'+ str(int(batch_target[frame_idx][0])),
                         box_color=box_color,
                         label=label,
@@ -816,19 +818,21 @@ class TrackNetValidator(BaseValidator):
                         stride = self.stride,
                         target=target_xy,
                         path='predict_val_FN_img',
+                        img_size=1280,
                         next=False,
                         loss=loss
-                        ) 
+                        )
 
                 display_predict_image(
-                            batch_img[frame_idx],  
-                            list(self.frame_10_metrics), 
+                            batch_img[frame_idx],
+                            list(self.frame_10_metrics),
                             'val_'+formatted_date+'_'+ str(int(batch_target[frame_idx][0])),
                             box_color=box_color,
                             label=label,
                             save_dir=self.metrics.save_dir,
                             stride = self.stride,
                             path='predict_val_10_frame_img',
+                            img_size=1280,
                             next=False,
                             only_ball=True,
                             loss=loss


### PR DESCRIPTION
## Summary
- allow `display_predict_image` to output custom sized images
- visualize validation predictions on 1280x1280 canvases

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6853d97c5b0c8323a3ed2ba2d57949e3