### PR TITLE
Fix bounding box center handling

### DIFF
--- a/ultralytics/multitask/configurable_dataset.py
+++ b/ultralytics/multitask/configurable_dataset.py
@@ -455,9 +455,12 @@ class MultiTaskConfigurableDataset(Dataset):
             kp_list = p.get("Keypoints", [])
             if not bbox or not kp_list:
                 continue
-            x1, y1 = bbox["X"], bbox["Y"]
-            x2 = x1 + bbox["Width"]
-            y2 = y1 + bbox["Height"]
+            cx, cy = bbox["X"], bbox["Y"]
+            bw, bh = bbox["Width"], bbox["Height"]
+            x1 = cx - bw / 2
+            y1 = cy - bh / 2
+            x2 = cx + bw / 2
+            y2 = cy + bh / 2
             points = self.transform_points([[x1, y1], [x2, y2]], w, h)
             x1, y1 = points[0]
             x2, y2 = points[1]

--- a/ultralytics/multitask/dataset.py
+++ b/ultralytics/multitask/dataset.py
@@ -439,9 +439,12 @@ class MultiTaskDataset(Dataset):
             kp_list = p.get("Keypoints", [])
             if not bbox or not kp_list:
                 continue
-            x1, y1 = bbox["X"], bbox["Y"]
-            x2 = x1 + bbox["Width"]
-            y2 = y1 + bbox["Height"]
+            cx, cy = bbox["X"], bbox["Y"]
+            bw, bh = bbox["Width"], bbox["Height"]
+            x1 = cx - bw / 2
+            y1 = cy - bh / 2
+            x2 = cx + bw / 2
+            y2 = cy + bh / 2
             points = self.transform_points([[x1, y1], [x2, y2]], w, h)
             x1, y1 = points[0]
             x2, y2 = points[1]

--- a/ultralytics/multitask/val_dataset.py
+++ b/ultralytics/multitask/val_dataset.py
@@ -401,9 +401,12 @@ class MultiTaskValDataset(Dataset):
             kp_list = p.get("Keypoints", [])
             if not bbox or not kp_list:
                 continue
-            x1, y1 = bbox["X"], bbox["Y"]
-            x2 = x1 + bbox["Width"]
-            y2 = y1 + bbox["Height"]
+            cx, cy = bbox["X"], bbox["Y"]
+            bw, bh = bbox["Width"], bbox["Height"]
+            x1 = cx - bw / 2
+            y1 = cy - bh / 2
+            x2 = cx + bw / 2
+            y2 = cy + bh / 2
             points = self.transform_points([[x1, y1], [x2, y2]], w, h)
             x1, y1 = points[0]
             x2, y2 = points[1]


### PR DESCRIPTION
## Summary
- adjust `process_players` to convert center-based boxes to corners

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68566c36ef0883239155864c4b840155