### PR TITLE
Fix pose model input channels

### DIFF
--- a/ultralytics/yolo/v8/pose/train.py
+++ b/ultralytics/yolo/v8/pose/train.py
@@ -20,7 +20,9 @@ class PoseTrainer(v8.detect.DetectionTrainer):
 
     def get_model(self, cfg=None, weights=None, verbose=True):
         """Get pose estimation model with specified configuration and weights."""
-        model = PoseModel(cfg, ch=3, nc=self.data['nc'], data_kpt_shape=self.data['kpt_shape'], verbose=verbose)
+        # Pose datasets in this repository use grayscale images, so set input
+        # channels to 1 instead of the RGB default of 3.
+        model = PoseModel(cfg, ch=1, nc=self.data['nc'], data_kpt_shape=self.data['kpt_shape'], verbose=verbose)
         if weights:
             model.load(weights)
 


### PR DESCRIPTION
## Summary
- support grayscale pose datasets by using single-channel inputs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cv2', 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6857c87e77448323be3f728f8af97e69