### PR TITLE
Add inference instructions

### DIFF
--- a/inference.py
+++ b/inference.py
@@ -1,0 +1,27 @@
+import argparse
+
+from ultralytics import YOLO
+
+
+def parse_args() -> argparse.Namespace:
+    """Return command line arguments."""
+    parser = argparse.ArgumentParser(description="YOLOv8 inference script")
+    parser.add_argument("--weights", required=True, help="Path to trained weight file")
+    parser.add_argument("--source", required=True, help="Image/video path, URL or webcam index")
+    parser.add_argument("--track", action="store_true", help="Enable tracking head")
+    parser.add_argument("--pose", action="store_true", help="Enable pose estimation head")
+    parser.add_argument("--save", action="store_true", help="Save prediction results")
+    parser.add_argument("--show", action="store_true", help="Display prediction results")
+    return parser.parse_args()
+
+
+def main(args: argparse.Namespace) -> None:
+    """Run inference using YOLOv8 model with custom weights."""
+    model = YOLO(args.weights)
+    model.predict(source=args.source, track=args.track, pose=args.pose, save=args.save, show=args.show)
+
+
+if __name__ == "__main__":
+    arguments = parse_args()
+    main(arguments)
+

--- a/ultralytics/multitask/README.md
+++ b/ultralytics/multitask/README.md
@@ -68,5 +68,17 @@ edit the file directly or supply a custom YAML on the command line via the
 python multitask.py --data path/to/your_multitask.yaml
 ```
 
+## inference.py 範例
+
+訓練完成後，可以使用 `inference.py` 來對圖片或影片進行推論，
+指令與 YOLOv8 CLI 相同，需提供權重檔與輸入來源：
+
+```bash
+python inference.py --weights path/to/best.pt --source path/to/image.jpg --save --show
+```
+
+加上 `--track` 會啟用 tracking head，`--pose` 則啟用姿態估計。
+預設輸出會儲存於 `runs/predict` 目錄。
+
 ## TODO
 - 挑影片的方式目前是寫死的


### PR DESCRIPTION
## Summary
- revise `inference.py` with helper `parse_args`
- add Chinese usage example in `ultralytics/multitask/README.md`

## Testing
- `pre-commit run --files inference.py ultralytics/multitask/README.md` *(fails: command not found)*
- `pytest -k inference` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68580f8b8cd08323a5eeb8c0ec637fb5