### PR TITLE
Fix dataset path

### DIFF
--- a/ultralytics/datasets/multitask.yaml
+++ b/ultralytics/datasets/multitask.yaml
@@ -17,7 +17,7 @@
 # ]
 
 # Root directory for images and labels
-path: ../ultralytics/ultralytics/multitask/dataset
+path: ../multitask/dataset
 train: train/all_profession
 val: val/all_profession
 # test: images/test

--- a/ultralytics/yolo/data/utils.py
+++ b/ultralytics/yolo/data/utils.py
@@ -226,7 +226,10 @@ def check_det_dataset(dataset, autodownload=True):
     path = Path(extract_dir or data.get('path') or Path(data.get('yaml_file', '')).parent)  # dataset root
 
     if not path.is_absolute():
-        path = (DATASETS_DIR / path).resolve()
+        candidate = (DATASETS_DIR / path).resolve()
+        if not candidate.exists():
+            candidate = (Path(data.get('yaml_file', '')).parent / path).resolve()
+        path = candidate
     data['path'] = path  # download scripts
     for k in 'train', 'val', 'test':
         if data.get(k):  # prepend path


### PR DESCRIPTION
## Summary
- correct dataset root in `multitask.yaml`
- resolve relative dataset paths from YAML location

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68581043031083238f7ab89606939d0a