### PR TITLE
Fix multitask class count

### DIFF
--- a/ultralytics/models/v8/multitask.yaml
+++ b/ultralytics/models/v8/multitask.yaml
@@ -2,7 +2,7 @@
 # YOLOv8 object detection model with P3-P5 outputs. For Usage examples see https://docs.ultralytics.com/tasks/detect
 
 # Parameters
-nc: 1  # number of classes
+nc: 2  # number of classes
 ch: 10
 kpt_shape: [17, 3]  # number of keypoints, number of dims (2 for x,y or 3 for x,y,visible)
 # feat_no: 8    # number of bbox feature sets per group


### PR DESCRIPTION
## Summary
- bump class count to 2 in `ultralytics/models/v8/multitask.yaml`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68581052ba108323956d9c1589d52502