### PR TITLE
Fix nc parameter in MultiTaskTrainer model init

### DIFF
--- a/ultralytics/multitask/train.py
+++ b/ultralytics/multitask/train.py
@@ -75,7 +75,7 @@ class MultiTaskTrainer(TrackNetTrainer):
         return build_dataloader(dataset, batch_size, workers, shuffle, rank, custom_sampler)
 
     def get_model(self, cfg=None, weights=None, verbose=True):
-        model = MultiTaskModel(cfg, verbose=verbose)
+        model = MultiTaskModel(cfg, nc=self.data["nc"], verbose=verbose)
         if weights:
             model.load(weights)
         return model


### PR DESCRIPTION
## Summary
- pass dataset class count when instantiating `MultiTaskModel`

## Testing
- `pre-commit run --files ultralytics/multitask/train.py` *(fails: command not found)*
- `pytest -k test_empty_dataset` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6858106588c0832386af6fd3fde357e3