### PR TITLE
Fix numpy resizing

### DIFF
--- a/ultralytics/multitask/configurable_dataset.py
+++ b/ultralytics/multitask/configurable_dataset.py
@@ -348,7 +348,7 @@ class TrackNetConfigurableDataset(Dataset):
         img = self.open_image(path)
         img = self.pad_to_square(img, pad_value)
         img = cv2.resize(img, dsize=(640, 640), interpolation=cv2.INTER_CUBIC)
-        img.resize((1, 640, 640))
+        img = img.reshape(1, 640, 640)
         return img
 
     def open_image(self, path):
@@ -480,7 +480,7 @@ class MultiTaskConfigurableDataset(Dataset):
         img = self.open_image(path)
         img = self.pad_to_square(img, pad_value)
         img = cv2.resize(img, dsize=(640, 640), interpolation=cv2.INTER_CUBIC)
-        img.resize((1, 640, 640))
+        img = img.reshape(1, 640, 640)
         return img
 
     def open_image(self, path):

--- a/ultralytics/multitask/dataset.py
+++ b/ultralytics/multitask/dataset.py
@@ -338,7 +338,7 @@ class TrackNetDataset(Dataset):
         img = self.open_image(path)
         img = self.pad_to_square(img, pad_value)
         img = cv2.resize(img, dsize=(640, 640), interpolation=cv2.INTER_CUBIC)
-        img.resize((1, 640, 640))
+        img = img.reshape(1, 640, 640)
         return img
 
     def open_image(self, path):

--- a/ultralytics/multitask/test_dataset.py
+++ b/ultralytics/multitask/test_dataset.py
@@ -212,7 +212,7 @@ class TrackNetTestDataset(Dataset):
     def __preprocess_img(self, path, pad_value=0):
         img = self.open_image(path)
         img = self.pad_to_square(img, pad_value)
-        img.resize((1, 640, 640))
+        img = img.reshape(1, 640, 640)
         return img
 
     def open_image(self, path):

--- a/ultralytics/multitask/val_dataset.py
+++ b/ultralytics/multitask/val_dataset.py
@@ -298,7 +298,7 @@ class TrackNetValDataset(Dataset):
         img = self.pad_to_square(img, pad_value)
         #self.display_image(img)
         img = cv2.resize(img, dsize=(640, 640), interpolation=cv2.INTER_CUBIC)
-        img.resize((1, 640, 640))
+        img = img.reshape(1, 640, 640)
         return img
 
     def open_image(self, path):
@@ -500,7 +500,7 @@ class MultiTaskValDataset(Dataset):
         img = self.open_image(path)
         img = self.pad_to_square(img, pad_value)
         img = cv2.resize(img, dsize=(640, 640), interpolation=cv2.INTER_CUBIC)
-        img.resize((1, 640, 640))
+        img = img.reshape(1, 640, 640)
         return img
 
     def open_image(self, path):

--- a/ultralytics/tracknet/configurable_dataset.py
+++ b/ultralytics/tracknet/configurable_dataset.py
@@ -351,7 +351,7 @@ class TrackNetConfigurableDataset(Dataset):
         img = self.open_image(path)
         img = self.pad_to_square(img, pad_value)
         img = cv2.resize(img, dsize=(640, 640), interpolation=cv2.INTER_CUBIC)
-        img.resize((1, 640, 640))
+        img = img.reshape(1, 640, 640)
         return img
 
     def open_image(self, path):

--- a/ultralytics/tracknet/dataset.py
+++ b/ultralytics/tracknet/dataset.py
@@ -328,7 +328,7 @@ class TrackNetDataset(Dataset):
         img = self.open_image(path)
         img = self.pad_to_square(img, pad_value)
         img = cv2.resize(img, dsize=(640, 640), interpolation=cv2.INTER_CUBIC)
-        img.resize((1, 640, 640))
+        img = img.reshape(1, 640, 640)
         return img
 
     def open_image(self, path):

--- a/ultralytics/tracknet/test_dataset.py
+++ b/ultralytics/tracknet/test_dataset.py
@@ -212,7 +212,7 @@ class TrackNetTestDataset(Dataset):
     def __preprocess_img(self, path, pad_value=0):
         img = self.open_image(path)
         img = self.pad_to_square(img, pad_value)
-        img.resize((1, 640, 640))
+        img = img.reshape(1, 640, 640)
         return img
 
     def open_image(self, path):

--- a/ultralytics/tracknet/val_dataset.py
+++ b/ultralytics/tracknet/val_dataset.py
@@ -293,7 +293,7 @@ class TrackNetValDataset(Dataset):
         img = self.pad_to_square(img, pad_value)
         #self.display_image(img)
         img = cv2.resize(img, dsize=(640, 640), interpolation=cv2.INTER_CUBIC)
-        img.resize((1, 640, 640))
+        img = img.reshape(1, 640, 640)
         return img
 
     def open_image(self, path):


### PR DESCRIPTION
## Summary
- reshape grayscale images instead of using numpy.resize

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*
- `pre-commit run --files ultralytics/multitask/configurable_dataset.py ultralytics/multitask/dataset.py ultralytics/multitask/test_dataset.py ultralytics/multitask/val_dataset.py ultralytics/tracknet/configurable_dataset.py ultralytics/tracknet/dataset.py ultralytics/tracknet/test_dataset.py ultralytics/tracknet/val_dataset.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858107c0e50832399228d4322ff086e