### PR TITLE
Add multi-task 11-channel model

### DIFF
--- a/merge_weights.py
+++ b/merge_weights.py
@@ -87,7 +87,7 @@ def main():
     args = ap.parse_args()
 
     sd_a, sd_b = load_sd(args.ckpt_a), load_sd(args.ckpt_b)
-    model = YOLO(args.yaml).model
+    model = YOLO(args.yaml, task="pose").model
     sd_new = model.state_dict()
 
     merged = merge_backbone(sd_a, sd_b, FIRST_KEY)

--- a/ultralytics/datasets/multi_11ch.yaml
+++ b/ultralytics/datasets/multi_11ch.yaml
@@ -7,4 +7,3 @@ kpt_shape: [17, 3]              # 17 個 keypoints (x, y, v)
 depth_multiple: 0.33            # 以下保持原 yolov8n
 width_multiple: 0.25
 # 其餘 backbone／neck／head 結構照抄官方 yaml 即可
----

--- a/ultralytics/models/v8/yolov8_multi_11ch.yaml
+++ b/ultralytics/models/v8/yolov8_multi_11ch.yaml
@@ -1,0 +1,49 @@
+# Ultralytics YOLO 🚀, AGPL-3.0 license
+# YOLOv8 multi-task model for 11-channel input with detection and pose heads.
+# Based on the default YOLOv8 pose configuration.
+
+# Parameters
+nc: 2  # number of classes
+kpt_shape: [17, 3]  # number of keypoints, number of dims (2 for x,y or 3 for x,y,visible)
+ch: 11  # input channels (1 grayscale + 10 heatmaps)
+scales: # model compound scaling constants, i.e. 'model=yolov8n-pose.yaml' will call yolov8-pose.yaml with scale 'n'
+  # [depth, width, max_channels]
+  n: [0.33, 0.25, 1024]
+  s: [0.33, 0.50, 1024]
+  m: [0.67, 0.75, 768]
+  l: [1.00, 1.00, 512]
+  x: [1.00, 1.25, 512]
+
+# YOLOv8.0n backbone
+backbone:
+  # [from, repeats, module, args]
+  - [-1, 1, Conv, [64, 3, 2]]  # 0-P1/2
+  - [-1, 1, Conv, [128, 3, 2]]  # 1-P2/4
+  - [-1, 3, C2f, [128, True]]
+  - [-1, 1, Conv, [256, 3, 2]]  # 3-P3/8
+  - [-1, 6, C2f, [256, True]]
+  - [-1, 1, Conv, [512, 3, 2]]  # 5-P4/16
+  - [-1, 6, C2f, [512, True]]
+  - [-1, 1, Conv, [1024, 3, 2]]  # 7-P5/32
+  - [-1, 3, C2f, [1024, True]]
+  - [-1, 1, SPPF, [1024, 5]]  # 9
+
+# YOLOv8.0n head
+head:
+  - [-1, 1, nn.Upsample, [None, 2, 'nearest']]
+  - [[-1, 6], 1, Concat, [1]]  # cat backbone P4
+  - [-1, 3, C2f, [512]]  # 12
+
+  - [-1, 1, nn.Upsample, [None, 2, 'nearest']]
+  - [[-1, 4], 1, Concat, [1]]  # cat backbone P3
+  - [-1, 3, C2f, [256]]  # 15 (P3/8-small)
+
+  - [-1, 1, Conv, [256, 3, 2]]
+  - [[-1, 12], 1, Concat, [1]]  # cat head P4
+  - [-1, 3, C2f, [512]]  # 18 (P4/16-medium)
+
+  - [-1, 1, Conv, [512, 3, 2]]
+  - [[-1, 9], 1, Concat, [1]]  # cat head P5
+  - [-1, 3, C2f, [1024]]  # 21 (P5/32-large)
+
+  - [[15, 18, 21], 1, Pose, [nc, kpt_shape]]  # Pose(P3, P4, P5)


### PR DESCRIPTION
## Summary
- add an 11‑channel YOLOv8 pose configuration
- load the config with `task="pose"` in `merge_weights.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_685922ab90c4832390bf7149c3ab80a5