### PR TITLE
Improve dataset emptiness checks

### DIFF
--- a/ultralytics/tracknet/configurable_dataset.py
+++ b/ultralytics/tracknet/configurable_dataset.py
@@ -20,6 +20,8 @@ class TrackNetConfigurableDataset(Dataset):
     def __init__(self, root_dir, num_input=10, transform=None, prefix=''):
 
         self.match_mog2 = {}
+        if not os.path.isdir(root_dir):
+            raise FileNotFoundError(f"Dataset directory not found: {root_dir}")
         self.root_dir = root_dir
         self.transform = transform
         self.num_input = num_input
@@ -41,9 +43,13 @@ class TrackNetConfigurableDataset(Dataset):
 
         image_count = len(glob(os.path.join(self.root_dir, "*/", "frame/", "*/", "*.png")))
 
+        matches = [m.strip('/') for m in glob("*/", root_dir=root_dir) if os.path.isdir(os.path.join(root_dir, m))]
+        if not matches:
+            raise FileNotFoundError(f"No match directories found in {self.root_dir}")
+
         # Traverse all matches
         last_len = 0
-        for match_name in glob("*/", root_dir=root_dir):
+        for match_name in matches:
             match_name = match_name.strip('/')
 
             match_dir_path = os.path.join(root_dir, match_name)
@@ -60,6 +66,12 @@ class TrackNetConfigurableDataset(Dataset):
                     self.read_match(match_name, pbar)
             print(f"Total samples for {match_name}: {len(self.samples)-last_len}\n")
             last_len = len(self.samples)
+
+        if len(self.samples) == 0:
+            raise FileNotFoundError(
+                f'No training samples found in {self.root_dir}. ' \
+                'Please verify the dataset files and annotations.'
+            )
 
 
     def read_match(self, match_name, pbar):

--- a/ultralytics/tracknet/dataset.py
+++ b/ultralytics/tracknet/dataset.py
@@ -15,6 +15,8 @@ from glob import glob
 class TrackNetDataset(Dataset):
     def __init__(self, root_dir, num_input=10, transform=None, prefix=''):
 
+        if not os.path.isdir(root_dir):
+            raise FileNotFoundError(f"Dataset directory not found: {root_dir}")
         self.root_dir = root_dir
         self.transform = transform
         self.num_input = num_input
@@ -25,10 +27,14 @@ class TrackNetDataset(Dataset):
 
         image_count = len(glob(os.path.join(self.root_dir, "*/", "frame/", "*/", "*.png")))
 
+        matches = [m.strip('/') for m in glob("*/", root_dir=root_dir) if os.path.isdir(os.path.join(root_dir, m))]
+        if not matches:
+            raise FileNotFoundError(f"No match directories found in {self.root_dir}")
+
         self.pbar = tqdm(total=image_count+(image_count-self.num_input*2+1)
                          +(image_count-self.num_input*3+1), miniters=1, smoothing=1)
         # Traverse all matches
-        for match_name in glob("*/", root_dir=root_dir):
+        for match_name in matches:
             match_name = match_name.strip('/')
 
             match_dir_path = os.path.join(root_dir, match_name)
@@ -39,6 +45,11 @@ class TrackNetDataset(Dataset):
 
             self.read_match(match_name)
         self.pbar.close()
+        if len(self.samples) == 0:
+            raise FileNotFoundError(
+                f'No training samples found in {self.root_dir}. '
+                'Please verify the dataset files and annotations.'
+            )
 
     def read_match(self, match_name):
         video_dir = os.path.join(self.root_dir, match_name, 'video')

--- a/ultralytics/tracknet/test_dataset.py
+++ b/ultralytics/tracknet/test_dataset.py
@@ -15,6 +15,8 @@ from glob import glob
 class TrackNetTestDataset(Dataset):
     def __init__(self, root_dir, num_input=10, transform=None, prefix=''):
 
+        if not os.path.isdir(root_dir):
+            raise FileNotFoundError(f"Dataset directory not found: {root_dir}")
         self.root_dir = root_dir
         self.transform = transform
         self.num_input = num_input
@@ -25,9 +27,13 @@ class TrackNetTestDataset(Dataset):
 
         image_count = len(glob(os.path.join(self.root_dir, "*/", "frame/", "*/", "*.png")))
 
+        matches = [m.strip('/') for m in glob("*/", root_dir=root_dir) if os.path.isdir(os.path.join(root_dir, m))]
+        if not matches:
+            raise FileNotFoundError(f"No match directories found in {self.root_dir}")
+
         self.pbar = tqdm(total=image_count, miniters=1, smoothing=1)
         # Traverse all matches
-        for match_name in glob("*/", root_dir=root_dir):
+        for match_name in matches:
             match_name = match_name.strip('/')
 
             match_dir_path = os.path.join(root_dir, match_name)
@@ -38,6 +44,11 @@ class TrackNetTestDataset(Dataset):
 
             self.read_match(match_name)
         self.pbar.close()
+        if len(self.samples) == 0:
+            raise FileNotFoundError(
+                f'No test samples found in {self.root_dir}. '
+                'Please verify the dataset files and annotations.'
+            )
 
     def read_match(self, match_name):
         video_dir = os.path.join(self.root_dir, match_name, 'video')

--- a/ultralytics/tracknet/val_dataset.py
+++ b/ultralytics/tracknet/val_dataset.py
@@ -19,6 +19,8 @@ class TrackNetValDataset(Dataset):
     def __init__(self, root_dir, num_input=10, transform=None, prefix=''):
         self.match_mog2 = {}
         self.total_ball = 0
+        if not os.path.isdir(root_dir):
+            raise FileNotFoundError(f"Dataset directory not found: {root_dir}")
         self.root_dir = root_dir
         self.transform = transform
         self.num_input = num_input
@@ -29,9 +31,13 @@ class TrackNetValDataset(Dataset):
 
         image_count = len(glob(os.path.join(self.root_dir, "*/", "frame/", "*/", "*.png")))
 
+        matches = [m.strip('/') for m in glob("*/", root_dir=root_dir) if os.path.isdir(os.path.join(root_dir, m))]
+        if not matches:
+            raise FileNotFoundError(f"No match directories found in {self.root_dir}")
+
         self.pbar = tqdm(total=image_count, miniters=1, smoothing=1)
         # Traverse all matches
-        for match_name in glob("*/", root_dir=root_dir):
+        for match_name in matches:
             match_name = match_name.strip('/')
 
             match_dir_path = os.path.join(root_dir, match_name)
@@ -42,6 +48,11 @@ class TrackNetValDataset(Dataset):
 
             self.read_match(match_name)
         self.pbar.close()
+        if len(self.samples) == 0:
+            raise FileNotFoundError(
+                f'No validation samples found in {self.root_dir}. '
+                'Please verify the dataset files and annotations.'
+            )
 
     def read_match(self, match_name):
         metadata_path = os.path.join(self.root_dir, match_name, 'metadata.json')

--- a/ultralytics/yolo/data/build.py
+++ b/ultralytics/yolo/data/build.py
@@ -93,6 +93,13 @@ def build_yolo_dataset(cfg, img_path, batch, data, mode='train', rect=False, str
 def build_dataloader(dataset, batch, workers, shuffle=True, rank=-1, custom_sampler=None):
     """Return an InfiniteDataLoader or DataLoader for training or validation set."""
     batch = min(batch, len(dataset))
+    if len(dataset) == 0 or batch <= 0:
+        root = getattr(dataset, 'root_dir', getattr(dataset, 'root', getattr(dataset, 'img_path', '')))
+        if root and not os.path.exists(root):
+            raise FileNotFoundError(f'Dataset path not found: {root}')
+        raise ValueError(
+            f'No images found in dataset at {root}. Please check your data paths and annotations.'
+        )
     nd = torch.cuda.device_count()  # number of CUDA devices
     nw = min([os.cpu_count() // max(nd, 1), batch if batch > 1 else 0, workers])  # number of workers
     if custom_sampler is not None:


### PR DESCRIPTION
## Summary
- raise FileNotFoundError when TrackNet datasets contain no samples
- clarify build_dataloader error with dataset path
- detect missing dataset directories earlier for all TrackNet datasets

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6859905ea7f08323a887d4f082b3ccf2