### PR TITLE
Improve dataset emptiness checks

### DIFF
--- a/train_multitask.py
+++ b/train_multitask.py
@@ -43,6 +43,12 @@ def parse_args() -> argparse.Namespace:
         default=3,
         help="凍結最前層數量",
     )
+    parser.add_argument(
+        "--use-resampler",
+        type=bool,
+        default=True,
+        help="是否於每個 epoch 使用 resampler",
+    )
     return parser.parse_args()
 
 
@@ -61,6 +67,7 @@ def main() -> None:
         optimizer=args.optimizer,
         batch=args.batch,
         freeze_layers=args.freeze_layers,
+        use_resampler=args.use_resampler,
     )
 
 

--- a/train_multitask.py
+++ b/train_multitask.py
@@ -6,7 +6,7 @@
 
     yolo train \
         model=./ultralytics/multitask/weights/multi_11ch_merged.pt \
-        data=multi.yaml \
+        data=ultralytics/datasets/multi_11ch.yaml \
         epochs=300 imgsz=640 device=0 \
         lr0=0.01 optimizer=SGD \
         freeze_layers=3
@@ -26,7 +26,11 @@ def parse_args() -> argparse.Namespace:
         default="./ultralytics/multitask/weights/multi_11ch_merged.pt",
         help="模型權重或配置路徑",
     )
-    parser.add_argument("--data", default="multi.yaml", help="資料設定檔")
+    parser.add_argument(
+        "--data",
+        default="ultralytics/datasets/multi_11ch.yaml",
+        help="資料設定檔",
+    )
     parser.add_argument("--epochs", type=int, default=300, help="訓練週期數")
     parser.add_argument("--imgsz", type=int, default=640, help="輸入尺寸")
     parser.add_argument("--device", default=0, help="使用的裝置")

--- a/train_multitask.py
+++ b/train_multitask.py
@@ -36,6 +36,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--device", default=0, help="使用的裝置")
     parser.add_argument("--lr0", type=float, default=0.01, help="初始學習率")
     parser.add_argument("--optimizer", default="SGD", help="最佳化器")
+    parser.add_argument("--batch", type=int, default=32, help="批次大小")
     parser.add_argument(
         "--freeze-layers",
         type=int,
@@ -58,6 +59,7 @@ def main() -> None:
         device=args.device,
         lr0=args.lr0,
         optimizer=args.optimizer,
+        batch=args.batch,
         freeze_layers=args.freeze_layers,
     )
 

--- a/ultralytics/datasets/multi_11ch.yaml
+++ b/ultralytics/datasets/multi_11ch.yaml
@@ -4,6 +4,10 @@ train: images/train
 val: images/val
 test: images/test
 
+# Input configuration
+# The dataset contains 11 grayscale frames stacked as channels.
+in_channels: 11
+
 # Detection classes
 nc: 2
 names:

--- a/ultralytics/datasets/multi_11ch.yaml
+++ b/ultralytics/datasets/multi_11ch.yaml
@@ -1,9 +1,13 @@
----
-# 以 yolov8n.yaml 為底，只列出需要改動的行
-in_channels: 11                # 1+10 = 11
-nc: 2                           # 兩類：shuttlecock, person
+# Multi-task dataset configuration
+path: ../datasets/multi             # dataset root directory
+train: images/train                 # train images (relative to 'path')
+val: images/val                     # validation images (relative to 'path')
+test: images/test                   # test images (optional)
+
+# Model configuration
+in_channels: 11                     # 1 grayscale + 10 heatmap channels
+nc: 2                               # classes: shuttlecock and person
 names: [shuttlecock, person]
-kpt_shape: [17, 3]              # 17 個 keypoints (x, y, v)
-depth_multiple: 0.33            # 以下保持原 yolov8n
+kpt_shape: [17, 3]                  # 17 keypoints with (x, y, visibility)
+depth_multiple: 0.33                # same as yolov8n
 width_multiple: 0.25
-# 其餘 backbone／neck／head 結構照抄官方 yaml 即可

--- a/ultralytics/datasets/multi_11ch.yaml
+++ b/ultralytics/datasets/multi_11ch.yaml
@@ -1,9 +1,35 @@
----
-# 以 yolov8n.yaml 為底，只列出需要改動的行
-in_channels: 11                # 1+10 = 11
-nc: 2                           # 兩類：shuttlecock, person
-names: [shuttlecock, person]
-kpt_shape: [17, 3]              # 17 個 keypoints (x, y, v)
-depth_multiple: 0.33            # 以下保持原 yolov8n
-width_multiple: 0.25
-# 其餘 backbone／neck／head 結構照抄官方 yaml 即可
+# Root directory for images and labels
+path: ../ultralytics/ultralytics/multitask/dataset
+train: images/train
+val: images/val
+test: images/test
+
+# Detection classes
+nc: 2
+names:
+  0: shettlecock
+  1: person
+
+# Pose configuration
+kpt_shape: [17, 3]
+flip_idx: [0, 2, 1, 4, 3, 6, 5, 8, 7, 10, 9, 12, 11, 14, 13, 16, 15]
+skeleton:
+  - [16, 14]
+  - [14, 12]
+  - [17, 15]
+  - [15, 13]
+  - [12, 13]
+  - [6, 12]
+  - [7, 13]
+  - [6, 7]
+  - [6, 8]
+  - [7, 9]
+  - [8, 10]
+  - [9, 11]
+  - [2, 3]
+  - [1, 2]
+  - [1, 3]
+  - [2, 4]
+  - [3, 5]
+  - [4, 6]
+  - [5, 7]

--- a/ultralytics/nn/modules/head.py
+++ b/ultralytics/nn/modules/head.py
@@ -376,6 +376,9 @@ class Pose(Detect):
     def forward(self, x):
         """Perform forward pass through YOLO model and return predictions."""
         bs = x[0].shape[0]  # batch size
+        if not self.training and (self.anchors.numel() == 0 or self.shape != x[0].shape):
+            self.anchors, self.strides = (y.transpose(0, 1) for y in make_anchors(x, self.stride, 0.5))
+            self.shape = x[0].shape
         kpt = torch.cat([self.cv4[i](x[i]).view(bs, self.nk, -1) for i in range(self.nl)], -1)  # (bs, 17*3, h*w)
         x = self.detect(self, x)
         if self.training:

--- a/ultralytics/tracknet/configurable_dataset.py
+++ b/ultralytics/tracknet/configurable_dataset.py
@@ -12,14 +12,16 @@ import torch.nn.functional as F
 from tqdm import tqdm
 from functools import lru_cache
 from glob import glob
+from concurrent.futures import ThreadPoolExecutor
 
 from ultralytics.tracknet.utils.preprocess import preprocess_csvV4
 from ultralytics.tracknet.utils.preprocess import preprocess_csv
 
 class TrackNetConfigurableDataset(Dataset):
-    def __init__(self, root_dir, num_input=10, transform=None, prefix=''):
+    def __init__(self, root_dir, num_input=10, transform=None, prefix='', cache_threads=1):
 
         self.match_mog2 = {}
+        self.cache_threads = max(int(cache_threads), 1)
         if not os.path.isdir(root_dir):
             raise FileNotFoundError(f"Dataset directory not found: {root_dir}")
         self.root_dir = root_dir
@@ -292,13 +294,19 @@ class TrackNetConfigurableDataset(Dataset):
         if os.path.isfile(npy_path):
             return
 
-        # generate cache
-        if getattr(self, 'flat_dataset', False):
-            frames = [cv2.imread(os.path.join(self.root_dir, fp), cv2.IMREAD_GRAYSCALE).astype(np.float32)
-                      for fp in img_files]
+        # generate cache using optional multithreading
+        def read_frame(fp):
+            if getattr(self, 'flat_dataset', False):
+                path = os.path.join(self.root_dir, fp)
+            else:
+                path = os.path.join(self.root_dir, match_name, 'frame', video_name, fp)
+            return cv2.imread(path, cv2.IMREAD_GRAYSCALE).astype(np.float32)
+
+        if self.cache_threads > 1 and len(img_files) > 1:
+            with ThreadPoolExecutor(max_workers=self.cache_threads) as ex:
+                frames = list(ex.map(read_frame, img_files))
         else:
-            frames = [cv2.imread(os.path.join(self.root_dir, match_name, 'frame', video_name, fp), cv2.IMREAD_GRAYSCALE).astype(np.float32)
-                      for fp in img_files]
+            frames = [read_frame(fp) for fp in img_files]
         frames = np.array(frames)  # 轉換為 NumPy 陣列
 
         if len(frames) == 0:
@@ -314,12 +322,17 @@ class TrackNetConfigurableDataset(Dataset):
             processed_frames = (frames - median_frame).astype(np.float32)
         else:
             processed_frames = frames
-        images = []
-        for i, processed_frame in enumerate(processed_frames):
-            img = self.pad_to_square(processed_frame)
+        def process_frame(proc_frame):
+            img = self.pad_to_square(proc_frame)
             img = cv2.resize(img, dsize=(640, 640), interpolation=cv2.INTER_CUBIC)
             img = np.expand_dims(img, axis=0)
-            images.append(img)
+            return img
+
+        if self.cache_threads > 1 and len(processed_frames) > 1:
+            with ThreadPoolExecutor(max_workers=self.cache_threads) as ex:
+                images = list(ex.map(process_frame, processed_frames))
+        else:
+            images = [process_frame(f) for f in processed_frames]
         img = np.concatenate(images, 0)
 
         np.save(npy_path, img)

--- a/ultralytics/tracknet/configurable_dataset.py
+++ b/ultralytics/tracknet/configurable_dataset.py
@@ -20,6 +20,8 @@ class TrackNetConfigurableDataset(Dataset):
     def __init__(self, root_dir, num_input=10, transform=None, prefix=''):
 
         self.match_mog2 = {}
+        if not os.path.isdir(root_dir):
+            raise FileNotFoundError(f"Dataset directory not found: {root_dir}")
         self.root_dir = root_dir
         self.transform = transform
         self.num_input = num_input
@@ -41,9 +43,13 @@ class TrackNetConfigurableDataset(Dataset):
 
         image_count = len(glob(os.path.join(self.root_dir, "*/", "frame/", "*/", "*.png")))
 
+        matches = [m.strip('/') for m in glob("*/", root_dir=root_dir) if os.path.isdir(os.path.join(root_dir, m))]
+        if not matches:
+            raise FileNotFoundError(f"No match directories found in {self.root_dir}")
+
         # Traverse all matches
         last_len = 0
-        for match_name in glob("*/", root_dir=root_dir):
+        for match_name in matches:
             match_name = match_name.strip('/')
 
             match_dir_path = os.path.join(root_dir, match_name)
@@ -60,6 +66,12 @@ class TrackNetConfigurableDataset(Dataset):
                     self.read_match(match_name, pbar)
             print(f"Total samples for {match_name}: {len(self.samples)-last_len}\n")
             last_len = len(self.samples)
+
+        if len(self.samples) == 0:
+            raise FileNotFoundError(
+                f'No training samples found in {self.root_dir}. ' \
+                'Please verify the dataset files and annotations.'
+            )
 
 
     def read_match(self, match_name, pbar):

--- a/ultralytics/tracknet/configurable_dataset.py
+++ b/ultralytics/tracknet/configurable_dataset.py
@@ -198,6 +198,13 @@ class TrackNetConfigurableDataset(Dataset):
         if not os.path.isdir(label_dir):
             raise FileNotFoundError(f"Labels directory not found for flat dataset: {label_dir}")
 
+        image_files = sorted(image_files)
+        if len(image_files) < self.num_input:
+            raise FileNotFoundError(
+                f"Flat dataset {self.root_dir} contains {len(image_files)} images, "
+                f"but {self.num_input} are required"
+            )
+
         first = self.open_image(os.path.join(self.root_dir, image_files[0]))
         h, w = first.shape
 

--- a/ultralytics/tracknet/configurable_dataset.py
+++ b/ultralytics/tracknet/configurable_dataset.py
@@ -44,8 +44,13 @@ class TrackNetConfigurableDataset(Dataset):
         image_count = len(glob(os.path.join(self.root_dir, "*/", "frame/", "*/", "*.png")))
 
         matches = [m.strip('/') for m in glob("*/", root_dir=root_dir) if os.path.isdir(os.path.join(root_dir, m))]
-        flat_images = sorted(glob('*.png', root_dir=root_dir) +
-                            glob('*.jpg', root_dir=root_dir))
+        flat_images = sorted(
+            glob('*.png', root_dir=root_dir) +
+            glob('*.jpg', root_dir=root_dir) +
+            glob('*.jpeg', root_dir=root_dir) +
+            glob('*.PNG', root_dir=root_dir) +
+            glob('*.JPG', root_dir=root_dir) +
+            glob('*.JPEG', root_dir=root_dir))
         if not matches and flat_images:
             self.flat_dataset = True
             self._load_flat_dataset(flat_images)
@@ -295,6 +300,9 @@ class TrackNetConfigurableDataset(Dataset):
             frames = [cv2.imread(os.path.join(self.root_dir, match_name, 'frame', video_name, fp), cv2.IMREAD_GRAYSCALE).astype(np.float32)
                       for fp in img_files]
         frames = np.array(frames)  # 轉換為 NumPy 陣列
+
+        if len(frames) == 0:
+            raise FileNotFoundError(f'No images loaded for cache generation: {img_files}')
 
         background_remove = False
 

--- a/ultralytics/tracknet/configurable_dataset.py
+++ b/ultralytics/tracknet/configurable_dataset.py
@@ -44,6 +44,11 @@ class TrackNetConfigurableDataset(Dataset):
         image_count = len(glob(os.path.join(self.root_dir, "*/", "frame/", "*/", "*.png")))
 
         matches = [m.strip('/') for m in glob("*/", root_dir=root_dir) if os.path.isdir(os.path.join(root_dir, m))]
+        flat_images = sorted(glob(os.path.join(root_dir, '*.png')) + glob(os.path.join(root_dir, '*.jpg')))
+        if not matches and flat_images:
+            self.flat_dataset = True
+            self._load_flat_dataset(flat_images)
+            return
         if not matches:
             raise FileNotFoundError(f"No match directories found in {self.root_dir}")
 
@@ -179,6 +184,47 @@ class TrackNetConfigurableDataset(Dataset):
                 
                 self.path_counts[match_name] = self.path_counts[match_name] - min_len
                 pbar.update(min_len)
+
+    def _load_flat_dataset(self, image_files):
+        label_dir = self.root_dir.replace(os.sep + 'images' + os.sep, os.sep + 'labels' + os.sep)
+        if not os.path.isdir(label_dir):
+            raise FileNotFoundError(f"Labels directory not found for flat dataset: {label_dir}")
+
+        first = self.open_image(os.path.join(self.root_dir, image_files[0]))
+        h, w = first.shape
+
+        records = []
+        for idx, f in enumerate(image_files):
+            label_file = os.path.join(label_dir, os.path.splitext(os.path.basename(f))[0] + '.txt')
+            vis, x_norm, y_norm = 0, 0.0, 0.0
+            if os.path.isfile(label_file):
+                with open(label_file) as lf:
+                    for line in lf:
+                        parts = line.strip().split()
+                        if parts and int(float(parts[0])) == 0 and len(parts) >= 3:
+                            x_norm, y_norm = float(parts[1]), float(parts[2])
+                            vis = 1
+                            break
+            X = x_norm * w
+            Y = y_norm * h
+            records.append([idx, vis, X, Y])
+
+        for i in range(len(records) - 1):
+            dx = -(records[i][2] - records[i + 1][2])
+            dy = -(records[i][3] - records[i + 1][3])
+            records[i].extend([dx, dy])
+        records[-1].extend([0.0, 0.0])
+        for r in records:
+            r.append(0)
+
+        for i in range(len(records) - (self.num_input - 1)):
+            frames = image_files[i:i + self.num_input]
+            target = np.array(records[i:i + self.num_input], dtype=np.float32)
+            target = self.transform_coordinates(target, w, h)
+            npy_path = self.img_cache_dir('flat', 'seq', frames)
+            self.samples.append({'match_name': 'flat', 'video_name': 'seq', 'cache_npy': npy_path,
+                                 'img_files': frames, 'target': target})
+            self.img_cache('flat', 'seq', frames, npy_path)
     def get_valid_downsample_steps(self, original_fps: int, min_fps: int) -> list[int]:
         return [step for step in range(2, original_fps + 1) if original_fps / step >= min_fps]
 
@@ -241,8 +287,12 @@ class TrackNetConfigurableDataset(Dataset):
             return
 
         # generate cache
-        frames = [cv2.imread(os.path.join(self.root_dir, match_name, 'frame', video_name, fp), cv2.IMREAD_GRAYSCALE).astype(np.float32) 
-                for fp in img_files]
+        if getattr(self, 'flat_dataset', False):
+            frames = [cv2.imread(os.path.join(self.root_dir, fp), cv2.IMREAD_GRAYSCALE).astype(np.float32)
+                      for fp in img_files]
+        else:
+            frames = [cv2.imread(os.path.join(self.root_dir, match_name, 'frame', video_name, fp), cv2.IMREAD_GRAYSCALE).astype(np.float32)
+                      for fp in img_files]
         frames = np.array(frames)  # 轉換為 NumPy 陣列
 
         background_remove = False
@@ -287,7 +337,10 @@ class TrackNetConfigurableDataset(Dataset):
         img = torch.from_numpy(img).float()
         target = torch.from_numpy(d['target'])
 
-        img_files = [f"{self.root_dir}/{d['match_name']}/frame/{d['video_name']}/{im}" for im in d['img_files']]
+        if getattr(self, 'flat_dataset', False):
+            img_files = [os.path.join(self.root_dir, im) for im in d['img_files']]
+        else:
+            img_files = [f"{self.root_dir}/{d['match_name']}/frame/{d['video_name']}/{im}" for im in d['img_files']]
 
         return {"img": img, "target": target, "img_files": img_files}
 

--- a/ultralytics/tracknet/configurable_dataset.py
+++ b/ultralytics/tracknet/configurable_dataset.py
@@ -44,7 +44,8 @@ class TrackNetConfigurableDataset(Dataset):
         image_count = len(glob(os.path.join(self.root_dir, "*/", "frame/", "*/", "*.png")))
 
         matches = [m.strip('/') for m in glob("*/", root_dir=root_dir) if os.path.isdir(os.path.join(root_dir, m))]
-        flat_images = sorted(glob(os.path.join(root_dir, '*.png')) + glob(os.path.join(root_dir, '*.jpg')))
+        flat_images = sorted(glob('*.png', root_dir=root_dir) +
+                            glob('*.jpg', root_dir=root_dir))
         if not matches and flat_images:
             self.flat_dataset = True
             self._load_flat_dataset(flat_images)
@@ -203,7 +204,7 @@ class TrackNetConfigurableDataset(Dataset):
                         parts = line.strip().split()
                         if parts and int(float(parts[0])) == 0 and len(parts) >= 3:
                             x_norm, y_norm = float(parts[1]), float(parts[2])
-                            vis = 1
+                            vis = int(float(parts[3])) if len(parts) >= 4 else 1
                             break
             X = x_norm * w
             Y = y_norm * h

--- a/ultralytics/tracknet/configurable_dataset.py
+++ b/ultralytics/tracknet/configurable_dataset.py
@@ -18,12 +18,16 @@ from ultralytics.tracknet.utils.preprocess import preprocess_csvV4
 from ultralytics.tracknet.utils.preprocess import preprocess_csv
 
 class TrackNetConfigurableDataset(Dataset):
-    def __init__(self, root_dir, num_input=10, transform=None, prefix='', cache_threads=1):
+    def __init__(self, root_dir, num_input=10, transform=None, prefix='', cache_threads=1, mode='train'):
 
         self.match_mog2 = {}
         self.cache_threads = max(int(cache_threads), 1)
         if not os.path.isdir(root_dir):
-            raise FileNotFoundError(f"Dataset directory not found: {root_dir}")
+            alt = os.path.join(root_dir, 'images', mode)
+            if os.path.isdir(alt):
+                root_dir = alt
+            else:
+                raise FileNotFoundError(f"Dataset directory not found: {root_dir}")
         self.root_dir = root_dir
         self.transform = transform
         self.num_input = num_input

--- a/ultralytics/tracknet/dataset.py
+++ b/ultralytics/tracknet/dataset.py
@@ -28,8 +28,13 @@ class TrackNetDataset(Dataset):
         image_count = len(glob(os.path.join(self.root_dir, "*/", "frame/", "*/", "*.png")))
 
         matches = [m.strip('/') for m in glob("*/", root_dir=root_dir) if os.path.isdir(os.path.join(root_dir, m))]
-        flat_images = sorted(glob('*.png', root_dir=root_dir) +
-                            glob('*.jpg', root_dir=root_dir))
+        flat_images = sorted(
+            glob('*.png', root_dir=root_dir) +
+            glob('*.jpg', root_dir=root_dir) +
+            glob('*.jpeg', root_dir=root_dir) +
+            glob('*.PNG', root_dir=root_dir) +
+            glob('*.JPG', root_dir=root_dir) +
+            glob('*.JPEG', root_dir=root_dir))
         if not matches and flat_images:
             self.flat_dataset = True
             self._load_flat_dataset(flat_images)
@@ -274,9 +279,14 @@ class TrackNetDataset(Dataset):
 
         # generate cache
         if getattr(self, 'flat_dataset', False):
-            images = [self.__preprocess_img(os.path.join(self.root_dir, img_file)) for img_file in img_files]
+            images = [self.__preprocess_img(os.path.join(self.root_dir, img_file))
+                      for img_file in img_files]
         else:
             images = [self.__preprocess_img(os.path.join(self.root_dir, match_name, 'frame', video_name, img_file)) for img_file in img_files]
+
+        if len(images) == 0:
+            raise FileNotFoundError(f'No images loaded for cache generation: {img_files}')
+
         img = np.concatenate(images, 0)
 
         np.save(npy_path, img)

--- a/ultralytics/tracknet/dataset.py
+++ b/ultralytics/tracknet/dataset.py
@@ -28,7 +28,8 @@ class TrackNetDataset(Dataset):
         image_count = len(glob(os.path.join(self.root_dir, "*/", "frame/", "*/", "*.png")))
 
         matches = [m.strip('/') for m in glob("*/", root_dir=root_dir) if os.path.isdir(os.path.join(root_dir, m))]
-        flat_images = sorted(glob(os.path.join(root_dir, '*.png')) + glob(os.path.join(root_dir, '*.jpg')))
+        flat_images = sorted(glob('*.png', root_dir=root_dir) +
+                            glob('*.jpg', root_dir=root_dir))
         if not matches and flat_images:
             self.flat_dataset = True
             self._load_flat_dataset(flat_images)
@@ -225,7 +226,7 @@ class TrackNetDataset(Dataset):
                         parts = line.strip().split()
                         if parts and int(float(parts[0])) == 0 and len(parts) >= 3:
                             x_norm, y_norm = float(parts[1]), float(parts[2])
-                            vis = 1
+                            vis = int(float(parts[3])) if len(parts) >= 4 else 1
                             break
             X = x_norm * w
             Y = y_norm * h

--- a/ultralytics/tracknet/dataset.py
+++ b/ultralytics/tracknet/dataset.py
@@ -14,10 +14,14 @@ from glob import glob
 from concurrent.futures import ThreadPoolExecutor
 
 class TrackNetDataset(Dataset):
-    def __init__(self, root_dir, num_input=10, transform=None, prefix='', cache_threads=1):
+    def __init__(self, root_dir, num_input=10, transform=None, prefix='', cache_threads=1, mode='train'):
 
         if not os.path.isdir(root_dir):
-            raise FileNotFoundError(f"Dataset directory not found: {root_dir}")
+            alt = os.path.join(root_dir, 'images', mode)
+            if os.path.isdir(alt):
+                root_dir = alt
+            else:
+                raise FileNotFoundError(f"Dataset directory not found: {root_dir}")
         self.root_dir = root_dir
         self.transform = transform
         self.num_input = num_input

--- a/ultralytics/tracknet/dataset.py
+++ b/ultralytics/tracknet/dataset.py
@@ -11,9 +11,10 @@ import torch.nn.functional as F
 from tqdm import tqdm
 from functools import lru_cache
 from glob import glob
+from concurrent.futures import ThreadPoolExecutor
 
 class TrackNetDataset(Dataset):
-    def __init__(self, root_dir, num_input=10, transform=None, prefix=''):
+    def __init__(self, root_dir, num_input=10, transform=None, prefix='', cache_threads=1):
 
         if not os.path.isdir(root_dir):
             raise FileNotFoundError(f"Dataset directory not found: {root_dir}")
@@ -22,6 +23,7 @@ class TrackNetDataset(Dataset):
         self.num_input = num_input
         self.samples = []
         self.prefix = prefix
+        self.cache_threads = max(int(cache_threads), 1)
 
         self.idx = set()
 
@@ -277,12 +279,19 @@ class TrackNetDataset(Dataset):
         if os.path.isfile(npy_path):
             return
 
-        # generate cache
-        if getattr(self, 'flat_dataset', False):
-            images = [self.__preprocess_img(os.path.join(self.root_dir, img_file))
-                      for img_file in img_files]
+        # generate cache using optional multithreading
+        def process(fp):
+            if getattr(self, 'flat_dataset', False):
+                path = os.path.join(self.root_dir, fp)
+            else:
+                path = os.path.join(self.root_dir, match_name, 'frame', video_name, fp)
+            return self.__preprocess_img(path)
+
+        if self.cache_threads > 1 and len(img_files) > 1:
+            with ThreadPoolExecutor(max_workers=self.cache_threads) as ex:
+                images = list(ex.map(process, img_files))
         else:
-            images = [self.__preprocess_img(os.path.join(self.root_dir, match_name, 'frame', video_name, img_file)) for img_file in img_files]
+            images = [process(fp) for fp in img_files]
 
         if len(images) == 0:
             raise FileNotFoundError(f'No images loaded for cache generation: {img_files}')

--- a/ultralytics/tracknet/dataset.py
+++ b/ultralytics/tracknet/dataset.py
@@ -220,6 +220,13 @@ class TrackNetDataset(Dataset):
         if not os.path.isdir(label_dir):
             raise FileNotFoundError(f"Labels directory not found for flat dataset: {label_dir}")
 
+        image_files = sorted(image_files)
+        if len(image_files) < self.num_input:
+            raise FileNotFoundError(
+                f"Flat dataset {self.root_dir} contains {len(image_files)} images, "
+                f"but {self.num_input} are required"
+            )
+
         first = self.open_image(os.path.join(self.root_dir, image_files[0]))
         h, w = first.shape
 

--- a/ultralytics/tracknet/dataset.py
+++ b/ultralytics/tracknet/dataset.py
@@ -28,6 +28,11 @@ class TrackNetDataset(Dataset):
         image_count = len(glob(os.path.join(self.root_dir, "*/", "frame/", "*/", "*.png")))
 
         matches = [m.strip('/') for m in glob("*/", root_dir=root_dir) if os.path.isdir(os.path.join(root_dir, m))]
+        flat_images = sorted(glob(os.path.join(root_dir, '*.png')) + glob(os.path.join(root_dir, '*.jpg')))
+        if not matches and flat_images:
+            self.flat_dataset = True
+            self._load_flat_dataset(flat_images)
+            return
         if not matches:
             raise FileNotFoundError(f"No match directories found in {self.root_dir}")
 
@@ -199,7 +204,54 @@ class TrackNetDataset(Dataset):
 
             #         self.img_cache(match_name, video_name, frames, npy_path)
 
-            self.pbar.update(self.num_input-1)
+        self.pbar.update(self.num_input-1)
+
+    def _load_flat_dataset(self, image_files):
+        """Load dataset arranged as images/ and labels/ folders."""
+        label_dir = self.root_dir.replace(os.sep + 'images' + os.sep, os.sep + 'labels' + os.sep)
+        if not os.path.isdir(label_dir):
+            raise FileNotFoundError(f"Labels directory not found for flat dataset: {label_dir}")
+
+        first = self.open_image(os.path.join(self.root_dir, image_files[0]))
+        h, w = first.shape
+
+        records = []
+        for idx, f in enumerate(image_files):
+            label_file = os.path.join(label_dir, os.path.splitext(os.path.basename(f))[0] + '.txt')
+            vis, x_norm, y_norm = 0, 0.0, 0.0
+            if os.path.isfile(label_file):
+                with open(label_file) as lf:
+                    for line in lf:
+                        parts = line.strip().split()
+                        if parts and int(float(parts[0])) == 0 and len(parts) >= 3:
+                            x_norm, y_norm = float(parts[1]), float(parts[2])
+                            vis = 1
+                            break
+            X = x_norm * w
+            Y = y_norm * h
+            records.append([idx, vis, X, Y])
+
+        for i in range(len(records) - 1):
+            dx = -(records[i][2] - records[i + 1][2])
+            dy = -(records[i][3] - records[i + 1][3])
+            records[i].extend([dx, dy])
+        records[-1].extend([0.0, 0.0])
+        for r in records:
+            r.append(0)
+
+        for i in range(len(records) - (self.num_input - 1)):
+            frames = image_files[i:i + self.num_input]
+            target = np.array(records[i:i + self.num_input], dtype=np.float32)
+            target = self.transform_coordinates(target, w, h)
+            npy_path = self.img_cache_dir('flat', 'seq', frames)
+            self.samples.append({
+                'match_name': 'flat',
+                'video_name': 'seq',
+                'cache_npy': npy_path,
+                'img_files': frames,
+                'target': target,
+            })
+            self.img_cache('flat', 'seq', frames, npy_path)
 
     def img_cache_dir(self, match_name, video_name, img_files):
         s = '|'.join([match_name]+[video_name]+img_files)
@@ -220,7 +272,10 @@ class TrackNetDataset(Dataset):
             return
 
         # generate cache
-        images = [self.__preprocess_img(os.path.join(self.root_dir, match_name, 'frame', video_name, img_file)) for img_file in img_files]
+        if getattr(self, 'flat_dataset', False):
+            images = [self.__preprocess_img(os.path.join(self.root_dir, img_file)) for img_file in img_files]
+        else:
+            images = [self.__preprocess_img(os.path.join(self.root_dir, match_name, 'frame', video_name, img_file)) for img_file in img_files]
         img = np.concatenate(images, 0)
 
         np.save(npy_path, img)
@@ -264,7 +319,10 @@ class TrackNetDataset(Dataset):
         img = torch.from_numpy(img).float()
         target = torch.from_numpy(d['target'])
 
-        img_files = [f"{self.root_dir}/../{im}" for im in d['img_files']]
+        if getattr(self, 'flat_dataset', False):
+            img_files = [os.path.join(self.root_dir, im) for im in d['img_files']]
+        else:
+            img_files = [f"{self.root_dir}/../{im}" for im in d['img_files']]
 
         return {"img": img, "target": target, "img_files": img_files}
 

--- a/ultralytics/tracknet/dataset.py
+++ b/ultralytics/tracknet/dataset.py
@@ -15,6 +15,8 @@ from glob import glob
 class TrackNetDataset(Dataset):
     def __init__(self, root_dir, num_input=10, transform=None, prefix=''):
 
+        if not os.path.isdir(root_dir):
+            raise FileNotFoundError(f"Dataset directory not found: {root_dir}")
         self.root_dir = root_dir
         self.transform = transform
         self.num_input = num_input
@@ -25,10 +27,14 @@ class TrackNetDataset(Dataset):
 
         image_count = len(glob(os.path.join(self.root_dir, "*/", "frame/", "*/", "*.png")))
 
+        matches = [m.strip('/') for m in glob("*/", root_dir=root_dir) if os.path.isdir(os.path.join(root_dir, m))]
+        if not matches:
+            raise FileNotFoundError(f"No match directories found in {self.root_dir}")
+
         self.pbar = tqdm(total=image_count+(image_count-self.num_input*2+1)
                          +(image_count-self.num_input*3+1), miniters=1, smoothing=1)
         # Traverse all matches
-        for match_name in glob("*/", root_dir=root_dir):
+        for match_name in matches:
             match_name = match_name.strip('/')
 
             match_dir_path = os.path.join(root_dir, match_name)
@@ -39,6 +45,11 @@ class TrackNetDataset(Dataset):
 
             self.read_match(match_name)
         self.pbar.close()
+        if len(self.samples) == 0:
+            raise FileNotFoundError(
+                f'No training samples found in {self.root_dir}. '
+                'Please verify the dataset files and annotations.'
+            )
 
     def read_match(self, match_name):
         video_dir = os.path.join(self.root_dir, match_name, 'video')

--- a/ultralytics/tracknet/test_dataset.py
+++ b/ultralytics/tracknet/test_dataset.py
@@ -28,8 +28,13 @@ class TrackNetTestDataset(Dataset):
         image_count = len(glob(os.path.join(self.root_dir, "*/", "frame/", "*/", "*.png")))
 
         matches = [m.strip('/') for m in glob("*/", root_dir=root_dir) if os.path.isdir(os.path.join(root_dir, m))]
-        flat_images = sorted(glob('*.png', root_dir=root_dir) +
-                            glob('*.jpg', root_dir=root_dir))
+        flat_images = sorted(
+            glob('*.png', root_dir=root_dir) +
+            glob('*.jpg', root_dir=root_dir) +
+            glob('*.jpeg', root_dir=root_dir) +
+            glob('*.PNG', root_dir=root_dir) +
+            glob('*.JPG', root_dir=root_dir) +
+            glob('*.JPEG', root_dir=root_dir))
         if not matches and flat_images:
             self.flat_dataset = True
             self._load_flat_dataset(flat_images)
@@ -128,9 +133,14 @@ class TrackNetTestDataset(Dataset):
 
         # generate cache
         if getattr(self, 'flat_dataset', False):
-            images = [self.__preprocess_img(os.path.join(self.root_dir, img_file)) for img_file in img_files]
+            images = [self.__preprocess_img(os.path.join(self.root_dir, img_file))
+                      for img_file in img_files]
         else:
             images = [self.__preprocess_img(os.path.join(self.root_dir, match_name, 'frame', video_name, img_file)) for img_file in img_files]
+
+        if len(images) == 0:
+            raise FileNotFoundError(f'No images loaded for cache generation: {img_files}')
+
         img = np.concatenate(images, 0)
 
         np.save(npy_path, img)

--- a/ultralytics/tracknet/test_dataset.py
+++ b/ultralytics/tracknet/test_dataset.py
@@ -28,7 +28,8 @@ class TrackNetTestDataset(Dataset):
         image_count = len(glob(os.path.join(self.root_dir, "*/", "frame/", "*/", "*.png")))
 
         matches = [m.strip('/') for m in glob("*/", root_dir=root_dir) if os.path.isdir(os.path.join(root_dir, m))]
-        flat_images = sorted(glob(os.path.join(root_dir, '*.png')) + glob(os.path.join(root_dir, '*.jpg')))
+        flat_images = sorted(glob('*.png', root_dir=root_dir) +
+                            glob('*.jpg', root_dir=root_dir))
         if not matches and flat_images:
             self.flat_dataset = True
             self._load_flat_dataset(flat_images)

--- a/ultralytics/tracknet/test_dataset.py
+++ b/ultralytics/tracknet/test_dataset.py
@@ -11,9 +11,10 @@ import torch.nn.functional as F
 from tqdm import tqdm
 from functools import lru_cache
 from glob import glob
+from concurrent.futures import ThreadPoolExecutor
 
 class TrackNetTestDataset(Dataset):
-    def __init__(self, root_dir, num_input=10, transform=None, prefix=''):
+    def __init__(self, root_dir, num_input=10, transform=None, prefix='', cache_threads=1):
 
         if not os.path.isdir(root_dir):
             raise FileNotFoundError(f"Dataset directory not found: {root_dir}")
@@ -22,6 +23,7 @@ class TrackNetTestDataset(Dataset):
         self.num_input = num_input
         self.samples = []
         self.prefix = prefix
+        self.cache_threads = max(int(cache_threads), 1)
 
         self.idx = set()
 
@@ -131,12 +133,19 @@ class TrackNetTestDataset(Dataset):
         if os.path.isfile(npy_path):
             return
 
-        # generate cache
-        if getattr(self, 'flat_dataset', False):
-            images = [self.__preprocess_img(os.path.join(self.root_dir, img_file))
-                      for img_file in img_files]
+        # generate cache using optional multithreading
+        def process(fp):
+            if getattr(self, 'flat_dataset', False):
+                path = os.path.join(self.root_dir, fp)
+            else:
+                path = os.path.join(self.root_dir, match_name, 'frame', video_name, fp)
+            return self.__preprocess_img(path)
+
+        if self.cache_threads > 1 and len(img_files) > 1:
+            with ThreadPoolExecutor(max_workers=self.cache_threads) as ex:
+                images = list(ex.map(process, img_files))
         else:
-            images = [self.__preprocess_img(os.path.join(self.root_dir, match_name, 'frame', video_name, img_file)) for img_file in img_files]
+            images = [process(fp) for fp in img_files]
 
         if len(images) == 0:
             raise FileNotFoundError(f'No images loaded for cache generation: {img_files}')

--- a/ultralytics/tracknet/test_dataset.py
+++ b/ultralytics/tracknet/test_dataset.py
@@ -15,6 +15,8 @@ from glob import glob
 class TrackNetTestDataset(Dataset):
     def __init__(self, root_dir, num_input=10, transform=None, prefix=''):
 
+        if not os.path.isdir(root_dir):
+            raise FileNotFoundError(f"Dataset directory not found: {root_dir}")
         self.root_dir = root_dir
         self.transform = transform
         self.num_input = num_input
@@ -25,9 +27,13 @@ class TrackNetTestDataset(Dataset):
 
         image_count = len(glob(os.path.join(self.root_dir, "*/", "frame/", "*/", "*.png")))
 
+        matches = [m.strip('/') for m in glob("*/", root_dir=root_dir) if os.path.isdir(os.path.join(root_dir, m))]
+        if not matches:
+            raise FileNotFoundError(f"No match directories found in {self.root_dir}")
+
         self.pbar = tqdm(total=image_count, miniters=1, smoothing=1)
         # Traverse all matches
-        for match_name in glob("*/", root_dir=root_dir):
+        for match_name in matches:
             match_name = match_name.strip('/')
 
             match_dir_path = os.path.join(root_dir, match_name)
@@ -38,6 +44,11 @@ class TrackNetTestDataset(Dataset):
 
             self.read_match(match_name)
         self.pbar.close()
+        if len(self.samples) == 0:
+            raise FileNotFoundError(
+                f'No test samples found in {self.root_dir}. '
+                'Please verify the dataset files and annotations.'
+            )
 
     def read_match(self, match_name):
         video_dir = os.path.join(self.root_dir, match_name, 'video')

--- a/ultralytics/tracknet/test_dataset.py
+++ b/ultralytics/tracknet/test_dataset.py
@@ -28,6 +28,11 @@ class TrackNetTestDataset(Dataset):
         image_count = len(glob(os.path.join(self.root_dir, "*/", "frame/", "*/", "*.png")))
 
         matches = [m.strip('/') for m in glob("*/", root_dir=root_dir) if os.path.isdir(os.path.join(root_dir, m))]
+        flat_images = sorted(glob(os.path.join(root_dir, '*.png')) + glob(os.path.join(root_dir, '*.jpg')))
+        if not matches and flat_images:
+            self.flat_dataset = True
+            self._load_flat_dataset(flat_images)
+            return
         if not matches:
             raise FileNotFoundError(f"No match directories found in {self.root_dir}")
 
@@ -87,6 +92,21 @@ class TrackNetTestDataset(Dataset):
 
             self.pbar.update(self.num_input-1)
 
+    def _load_flat_dataset(self, image_files):
+        label_dir = self.root_dir.replace(os.sep + 'images' + os.sep, os.sep + 'labels' + os.sep)
+        if not os.path.isdir(label_dir):
+            raise FileNotFoundError(f"Labels directory not found for flat dataset: {label_dir}")
+
+        first = self.open_image(os.path.join(self.root_dir, image_files[0]))
+        h, w = first.shape
+
+        for i in range(len(image_files) - (self.num_input - 1)):
+            frames = image_files[i:i + self.num_input]
+            npy_path = self.img_cache_dir('flat', 'seq', frames)
+            self.samples.append({'match_name': 'flat', 'video_name': 'seq', 'cache_npy': npy_path,
+                                 'img_files': frames})
+            self.img_cache('flat', 'seq', frames, npy_path)
+
     def img_cache_dir(self, match_name, video_name, img_files):
         s = '|'.join([match_name]+[video_name]+img_files)
         filename = hashlib.sha1(s.encode('utf-8')).hexdigest()
@@ -106,7 +126,10 @@ class TrackNetTestDataset(Dataset):
             return
 
         # generate cache
-        images = [self.__preprocess_img(os.path.join(self.root_dir, match_name, 'frame', video_name, img_file)) for img_file in img_files]
+        if getattr(self, 'flat_dataset', False):
+            images = [self.__preprocess_img(os.path.join(self.root_dir, img_file)) for img_file in img_files]
+        else:
+            images = [self.__preprocess_img(os.path.join(self.root_dir, match_name, 'frame', video_name, img_file)) for img_file in img_files]
         img = np.concatenate(images, 0)
 
         np.save(npy_path, img)
@@ -149,7 +172,10 @@ class TrackNetTestDataset(Dataset):
 
         img = torch.from_numpy(img).float()
 
-        img_files = [f"{self.root_dir}/../{im}" for im in d['img_files']]
+        if getattr(self, 'flat_dataset', False):
+            img_files = [os.path.join(self.root_dir, im) for im in d['img_files']]
+        else:
+            img_files = [f"{self.root_dir}/../{im}" for im in d['img_files']]
 
         return {"img": img, "img_files": img_files}
 

--- a/ultralytics/tracknet/test_dataset.py
+++ b/ultralytics/tracknet/test_dataset.py
@@ -105,6 +105,13 @@ class TrackNetTestDataset(Dataset):
         if not os.path.isdir(label_dir):
             raise FileNotFoundError(f"Labels directory not found for flat dataset: {label_dir}")
 
+        image_files = sorted(image_files)
+        if len(image_files) < self.num_input:
+            raise FileNotFoundError(
+                f"Flat dataset {self.root_dir} contains {len(image_files)} images, "
+                f"but {self.num_input} are required"
+            )
+
         first = self.open_image(os.path.join(self.root_dir, image_files[0]))
         h, w = first.shape
 

--- a/ultralytics/tracknet/train.py
+++ b/ultralytics/tracknet/train.py
@@ -13,9 +13,9 @@ class TrackNetTrainer(DetectionTrainer):
     def build_dataset(self, img_path, mode='train', batch=None):
         """Build TrackNet datasets using the model's expected channel count."""
 
-        # Determine required input channels from the loaded model if available.
+        # Determine required sequence length from the detection head
         try:
-            num_input = int(getattr(self.model, 'yaml', {}).get('ch', 10))
+            num_input = int(getattr(self.model.model[-1], 'num_groups', 10))
         except Exception:
             num_input = 10
 

--- a/ultralytics/tracknet/train.py
+++ b/ultralytics/tracknet/train.py
@@ -13,11 +13,8 @@ class TrackNetTrainer(DetectionTrainer):
     def build_dataset(self, img_path, mode='train', batch=None):
         """Build TrackNet datasets using the model's expected channel count."""
 
-        # Determine required sequence length from the detection head
-        try:
-            num_input = int(getattr(self.model.model[-1], 'num_groups', 10))
-        except Exception:
-            num_input = 10
+        # Determine required sequence length from dataset configuration
+        num_input = int(self.data.get('in_channels', 10))
 
         if mode == 'train':
             dataset = TrackNetConfigurableDataset(root_dir=img_path, num_input=num_input)
@@ -27,7 +24,8 @@ class TrackNetTrainer(DetectionTrainer):
             return dataset
 
     def get_model(self, cfg=None, weights=None, verbose=True):
-        self.tracknet_model = TrackNetV4Model(cfg, ch=10, nc=self.data['nc'], verbose=verbose and RANK == -1)
+        in_ch = int(self.data.get('in_channels', 10))
+        self.tracknet_model = TrackNetV4Model(cfg, ch=in_ch, nc=self.data['nc'], verbose=verbose and RANK == -1)
         if weights:
             self.tracknet_model.load(weights)
         return self.tracknet_model

--- a/ultralytics/tracknet/train.py
+++ b/ultralytics/tracknet/train.py
@@ -11,17 +11,19 @@ import torch
 
 class TrackNetTrainer(DetectionTrainer):
     def build_dataset(self, img_path, mode='train', batch=None):
-        # generator = torch.Generator().manual_seed(42)
-        # dataset = TrackNetConfigurableDataset(root_dir=img_path)
-        # train_size = int(0.8 * len(dataset))  # 70% 的數據作為訓練集
-        # val_size = len(dataset) - train_size  # 剩下的 30% 作為驗證集
-        # train_dataset, val_dataset = random_split(dataset, [train_size, val_size], generator)
+        """Build TrackNet datasets using the model's expected channel count."""
+
+        # Determine required input channels from the loaded model if available.
+        try:
+            num_input = int(getattr(self.model, 'yaml', {}).get('ch', 10))
+        except Exception:
+            num_input = 10
 
         if mode == 'train':
-            dataset = TrackNetConfigurableDataset(root_dir=img_path)
+            dataset = TrackNetConfigurableDataset(root_dir=img_path, num_input=num_input)
             return dataset
         else:
-            dataset = TrackNetValDataset(root_dir=img_path)
+            dataset = TrackNetValDataset(root_dir=img_path, num_input=num_input)
             return dataset
 
     def get_model(self, cfg=None, weights=None, verbose=True):

--- a/ultralytics/tracknet/train.py
+++ b/ultralytics/tracknet/train.py
@@ -17,10 +17,10 @@ class TrackNetTrainer(DetectionTrainer):
         num_input = int(self.data.get('in_channels', 10))
 
         if mode == 'train':
-            dataset = TrackNetConfigurableDataset(root_dir=img_path, num_input=num_input)
+            dataset = TrackNetConfigurableDataset(root_dir=img_path, num_input=num_input, mode='train')
             return dataset
         else:
-            dataset = TrackNetValDataset(root_dir=img_path, num_input=num_input)
+            dataset = TrackNetValDataset(root_dir=img_path, num_input=num_input, mode='val')
             return dataset
 
     def get_model(self, cfg=None, weights=None, verbose=True):

--- a/ultralytics/tracknet/utils/confusion_matrix.py
+++ b/ultralytics/tracknet/utils/confusion_matrix.py
@@ -57,7 +57,7 @@ class ConfConfusionMatrix:
             f1 = 2*self.conf_precision*self.recall/(self.conf_precision+self.recall)
         data_row = [self.conf_TN, self.conf_FP, self.conf_FN, self.conf_TP, self.conf_acc, self.conf_precision, self.recall, f1]
         csv_file_path = r'/Users/bartek/git/BartekTao/datasets/tracknet/val_confusion_matrix/conf_matrix.csv'
-        csv_file_path = r'/usr/src/datasets/tracknet/val_confusion_matrix/conf_matrix.csv'
+        csv_file_path = r'/storage/Multi/ultralytics/ultralytics/multitask/dataset/val_confusion_matrix/conf_matrix.csv'
         with open(csv_file_path, mode='a', newline='') as file:
             writer = csv.writer(file)
             

--- a/ultralytics/tracknet/utils/loss.py
+++ b/ultralytics/tracknet/utils/loss.py
@@ -229,6 +229,12 @@ class TrackNetLoss:
         feats = preds[1] if isinstance(preds, tuple) else preds
 
         for i, feat in enumerate(feats):
+            channels = feat.shape[1]
+            if channels % self.no != 0:
+                raise ValueError(
+                    f"Invalid output channels {channels}, expected a multiple of {self.no}. "
+                    "Ensure dataset 'nc' matches the model configuration." )
+
             pred_distri, pred_scores = feat.view(feat.shape[0], self.no, -1).split(
                 (self.reg_max * self.feat_no, self.nc), 1)
             

--- a/ultralytics/tracknet/utils/loss.py
+++ b/ultralytics/tracknet/utils/loss.py
@@ -82,6 +82,8 @@ class TrackNetLossWithHit:
             
             mask_has_ball = torch.zeros_like(target_pos)
             for target_idx, target in enumerate(batch_target[idx]):
+                if target_idx >= self.num_groups:
+                    break
                 if target[6] == 1:
                     grid_x, grid_y, offset_x, offset_y = target_grid(target[2], target[3], stride)
                     hit_targets[target_idx, grid_y, grid_x] = 1
@@ -209,7 +211,7 @@ class TrackNetLoss:
         self.no = m.no
         self.reg_max = m.reg_max
         self.feat_no = m.feat_no
-        self.num_groups = 10
+        self.num_groups = int(getattr(model, 'yaml', {}).get('ch', 10))
         self.device = device
 
         self.use_dfl = m.reg_max > 1
@@ -266,6 +268,8 @@ class TrackNetLoss:
                 stride = self.stride[i]
                 
                 for target_idx, target in enumerate(batch_target[idx]):
+                    if target_idx >= self.num_groups:
+                        break
                     # target xy
                     grid_x, grid_y, offset_x, offset_y = target_grid(target[2], target[3], stride)
                     if grid_x >= 80 or grid_y >= 80:
@@ -406,8 +410,10 @@ class TrackNetLossV5:
         for idx, _ in enumerate(batch_target):
             # pred = [330 * cell_num * cell_num]
             stride = self.stride[0]
-            
+
             for target_idx, target in enumerate(batch_target[idx]):
+                if target_idx >= self.num_groups:
+                    break
                 # target xy
                 grid_x, grid_y, offset_x, offset_y = target_grid(target[2], target[3], stride)
                 # 找出快球 => 慢球, 慢球 => 快球
@@ -576,8 +582,10 @@ class TrackNetLossV4:
         for idx, _ in enumerate(batch_target):
             # pred = [330 * 20 * 20]
             stride = self.stride[0]
-            
+
             for target_idx, target in enumerate(batch_target[idx]):
+                if target_idx >= self.num_groups:
+                    break
                 # target xy
                 grid_x, grid_y, offset_x, offset_y = target_grid(target[2], target[3], stride)
                 # 找出快球 => 慢球, 慢球 => 快球
@@ -744,8 +752,10 @@ class TrackNetLossV3:
         for idx, _ in enumerate(batch_target):
             # pred = [330 * 20 * 20]
             stride = self.stride[0]
-            
+
             for target_idx, target in enumerate(batch_target[idx]):
+                if target_idx >= self.num_groups:
+                    break
                 if target[1] == 1:
                     # xy
                     grid_x, grid_y, offset_x, offset_y = target_grid(target[2], target[3], stride)

--- a/ultralytics/tracknet/utils/loss.py
+++ b/ultralytics/tracknet/utils/loss.py
@@ -226,7 +226,7 @@ class TrackNetLoss:
     def __call__(self, preds, batch):
         loss = torch.zeros(2, device=self.device)
 
-        feats = preds[1] if isinstance(preds, tuple) else preds
+        feats = preds[0] if isinstance(preds, tuple) else preds
 
         for i, feat in enumerate(feats):
             channels = feat.shape[1]
@@ -377,7 +377,7 @@ class TrackNetLossV5:
         self.confusion_class = confusion_class
 
     def __call__(self, preds, batch):
-        feats = preds[1] if isinstance(preds, tuple) else preds
+        feats = preds[0] if isinstance(preds, tuple) else preds
         pred_distri, pred_scores = torch.cat([xi.view(feats[0].shape[0], self.no, -1) for xi in feats], 2).split(
             (self.reg_max * self.feat_no, self.nc), 1)
         
@@ -548,7 +548,7 @@ class TrackNetLossV4:
         self.confusion_class = confusion_class
 
     def __call__(self, preds, batch):
-        feats = preds[1] if isinstance(preds, tuple) else preds
+        feats = preds[0] if isinstance(preds, tuple) else preds
         pred_distri, pred_scores = torch.cat([xi.view(feats[0].shape[0], self.no, -1) for xi in feats], 2).split(
             (self.reg_max * self.feat_no, self.nc), 1)
         
@@ -719,7 +719,7 @@ class TrackNetLossV3:
         self.confusion_class = confusion_class
 
     def __call__(self, preds, batch):
-        feats = preds[1] if isinstance(preds, tuple) else preds
+        feats = preds[0] if isinstance(preds, tuple) else preds
         pred_distri, pred_scores, pred_dxdy = torch.cat([xi.view(feats[0].shape[0], self.no, -1) for xi in feats], 2).split(
             (self.reg_max * self.feat_no, self.nc, self.dxdy_no), 1)
         

--- a/ultralytics/tracknet/utils/loss.py
+++ b/ultralytics/tracknet/utils/loss.py
@@ -810,9 +810,13 @@ class FocalLossWithMask(nn.Module):
 
     # OHEM
     def top_k_sampling(self, loss, labels, negative_ratio=3.0):
-        """
-        Hard Negative Mining: Selects the hardest negative examples based on the loss.
-        """
+        """Select the hardest negative samples for focal loss."""
+
+        if loss.ndim == 3:
+            loss = loss[..., 1]
+        if labels.ndim == 3:
+            labels = labels[..., 1]
+
         pos_mask = labels > 0
         num_pos = pos_mask.sum(dim=1, keepdim=True)
         num_neg = negative_ratio * num_pos
@@ -822,11 +826,9 @@ class FocalLossWithMask(nn.Module):
         _, indices = loss_for_sort.sort(dim=1, descending=True)
 
         neg_mask = torch.zeros_like(labels, dtype=torch.bool)
-        for i in range(loss.size(0)):  
+        for i in range(loss.size(0)):
             num_neg_samples = int(num_neg[i].item()) if int(num_neg[i].item()) != 0 else int(negative_ratio)
-            # num_neg_samples = 640
-            # num_neg_samples = int(num_neg[i].item())
-            neg_mask[i, indices[i, :num_neg_samples]] = True 
+            neg_mask[i, indices[i, :num_neg_samples]] = True
 
         return pos_mask | neg_mask
 
@@ -869,7 +871,7 @@ class FocalLossWithMask(nn.Module):
 
         w = (alpha/(1-alpha))
 
-        loss = loss * relevant_mask.float()
+        loss = loss * relevant_mask.unsqueeze(-1).float()
 
         # loss[FN_mask] *= negative_ratio*20*w
         # loss[FP_mask & ~may_has_ball] *= negative_ratio*15*w

--- a/ultralytics/tracknet/utils/loss.py
+++ b/ultralytics/tracknet/utils/loss.py
@@ -82,6 +82,8 @@ class TrackNetLossWithHit:
             
             mask_has_ball = torch.zeros_like(target_pos)
             for target_idx, target in enumerate(batch_target[idx]):
+                if target_idx >= self.num_groups:
+                    break
                 if target[6] == 1:
                     grid_x, grid_y, offset_x, offset_y = target_grid(target[2], target[3], stride)
                     hit_targets[target_idx, grid_y, grid_x] = 1
@@ -209,7 +211,7 @@ class TrackNetLoss:
         self.no = m.no
         self.reg_max = m.reg_max
         self.feat_no = m.feat_no
-        self.num_groups = 10
+        self.num_groups = getattr(model.model[-1], 'num_groups', 10)
         self.device = device
 
         self.use_dfl = m.reg_max > 1
@@ -266,6 +268,8 @@ class TrackNetLoss:
                 stride = self.stride[i]
                 
                 for target_idx, target in enumerate(batch_target[idx]):
+                    if target_idx >= self.num_groups:
+                        break
                     # target xy
                     grid_x, grid_y, offset_x, offset_y = target_grid(target[2], target[3], stride)
                     if grid_x >= 80 or grid_y >= 80:
@@ -406,8 +410,10 @@ class TrackNetLossV5:
         for idx, _ in enumerate(batch_target):
             # pred = [330 * cell_num * cell_num]
             stride = self.stride[0]
-            
+
             for target_idx, target in enumerate(batch_target[idx]):
+                if target_idx >= self.num_groups:
+                    break
                 # target xy
                 grid_x, grid_y, offset_x, offset_y = target_grid(target[2], target[3], stride)
                 # 找出快球 => 慢球, 慢球 => 快球
@@ -576,8 +582,10 @@ class TrackNetLossV4:
         for idx, _ in enumerate(batch_target):
             # pred = [330 * 20 * 20]
             stride = self.stride[0]
-            
+
             for target_idx, target in enumerate(batch_target[idx]):
+                if target_idx >= self.num_groups:
+                    break
                 # target xy
                 grid_x, grid_y, offset_x, offset_y = target_grid(target[2], target[3], stride)
                 # 找出快球 => 慢球, 慢球 => 快球
@@ -744,8 +752,10 @@ class TrackNetLossV3:
         for idx, _ in enumerate(batch_target):
             # pred = [330 * 20 * 20]
             stride = self.stride[0]
-            
+
             for target_idx, target in enumerate(batch_target[idx]):
+                if target_idx >= self.num_groups:
+                    break
                 if target[1] == 1:
                     # xy
                     grid_x, grid_y, offset_x, offset_y = target_grid(target[2], target[3], stride)

--- a/ultralytics/tracknet/utils/loss.py
+++ b/ultralytics/tracknet/utils/loss.py
@@ -231,9 +231,11 @@ class TrackNetLoss:
         for i, feat in enumerate(feats):
             channels = feat.shape[1]
             if channels % self.no != 0:
+                expected_cls = self.no - self.reg_max * self.feat_no
                 raise ValueError(
-                    f"Invalid output channels {channels}, expected a multiple of {self.no}. "
-                    "Ensure dataset 'nc' matches the model configuration." )
+                    f"Invalid output channels {channels}. Got 'nc'={self.nc} and no={self.no} (" \
+                    f"expected cls channels {expected_cls}). Check that the dataset "
+                    "and model configuration use the same number of classes." )
 
             pred_distri, pred_scores = feat.view(feat.shape[0], self.no, -1).split(
                 (self.reg_max * self.feat_no, self.nc), 1)

--- a/ultralytics/tracknet/utils/loss.py
+++ b/ultralytics/tracknet/utils/loss.py
@@ -832,6 +832,10 @@ class FocalLossWithMask(nn.Module):
 
     def forward(self, pred, label, gamma=2, alpha=0.75, negative_ratio=3.0):
         """Calculates and updates confusion matrix for object detection/classification tasks."""
+        # If label is (B, N, 1) but pred is (B, N, 2), expand label to one-hot
+        if label.shape[-1] == 1 and pred.shape[-1] == 2:
+            label = torch.cat([1 - label, label], dim=-1)
+
         assert torch.all((label == 0) | (label == 1)), f"`label` contains invalid values: {label.unique()}"
         loss = F.binary_cross_entropy_with_logits(pred, label, reduction='none')
         assert (loss >= 0).all(), f"`loss` contains negative values. Min: {loss.min()}, Max: {loss.max()}"

--- a/ultralytics/tracknet/val.py
+++ b/ultralytics/tracknet/val.py
@@ -28,7 +28,7 @@ class TrackNetValidatorV3(BaseValidator):
     
     def get_dataloader(self, dataset_path, batch_size):
         """For TrackNet, we can use the provided TrackNetDataset to get the dataloader."""
-        dataset = TrackNetDataset(root_dir=dataset_path)
+        dataset = TrackNetDataset(root_dir=dataset_path, mode='val')
         return build_dataloader(dataset, batch_size, self.args.workers, shuffle=False, rank=-1)
     
     def preprocess_batch(self, batch):
@@ -1571,7 +1571,7 @@ class TrackNetValidatorWithHit(BaseValidator):
     
     def get_dataloader(self, dataset_path, batch_size):
         """For TrackNet, we can use the provided TrackNetDataset to get the dataloader."""
-        dataset = TrackNetDataset(root_dir=dataset_path)
+        dataset = TrackNetDataset(root_dir=dataset_path, mode='val')
         return build_dataloader(dataset, batch_size, self.args.workers, shuffle=False, rank=-1)
     
     def preprocess_batch(self, batch):

--- a/ultralytics/tracknet/val.py
+++ b/ultralytics/tracknet/val.py
@@ -53,7 +53,7 @@ class TrackNetValidatorV3(BaseValidator):
         """Initialize some metrics."""
         # Placeholder for any metrics you might want to use.
         self.stride = 32
-        self.num_groups = 10
+        self.num_groups = int(getattr(model, 'yaml', {}).get('ch', 10))
 
         self.total_loss = 0.0
         self.num_samples = 0
@@ -121,6 +121,8 @@ class TrackNetValidatorV3(BaseValidator):
         target_mov = torch.zeros(self.num_groups, 20, 20, 2, device=self.device)
 
         for target_idx, target in enumerate(batch_target):
+            if target_idx >= self.num_groups:
+                break
             if target[1] == 1:
                 # xy
                 grid_x, grid_y, offset_x, offset_y = target_grid(target[2], target[3], self.stride)
@@ -585,6 +587,8 @@ class TrackNetValidator(BaseValidator):
         cls_targets = torch.zeros(self.num_groups, self.cell_num, self.cell_num, 1, device=self.device)
         
         for target_idx, target in enumerate(batch_target):
+            if target_idx >= self.num_groups:
+                break
             grid_x, grid_y, offset_x, offset_y = target_grid(target[2], target[3], self.stride)
             if grid_x >= 80:
                 print(grid_x, grid_y, offset_x, offset_y)
@@ -1145,6 +1149,8 @@ class TrackNetValidatorV2(BaseValidator):
         mask_hit_ball_v2 = torch.zeros(self.num_groups, 1, device=self.device)
 
         for target_idx, target in enumerate(batch_target):
+            if target_idx >= self.num_groups:
+                break
             grid_x, grid_y, offset_x, offset_y = target_grid(target[2], target[3], self.stride)
 
             # 找出快球 => 慢球, 慢球 => 快球
@@ -1641,6 +1647,8 @@ class TrackNetValidatorWithHit(BaseValidator):
         if len(batch_target.shape) == 3:
             batch_target = batch_target[0]
         for idx, target in enumerate(batch_target):
+            if idx >= self.num_groups:
+                break
             if target[1] == 1:
                 # xy
                 grid_x, grid_y, offset_x, offset_y = target_grid(target[2], target[3], stride)

--- a/ultralytics/tracknet/val.py
+++ b/ultralytics/tracknet/val.py
@@ -53,7 +53,7 @@ class TrackNetValidatorV3(BaseValidator):
         """Initialize some metrics."""
         # Placeholder for any metrics you might want to use.
         self.stride = 32
-        self.num_groups = 10
+        self.num_groups = getattr(model.model[-1], 'num_groups', 10)
 
         self.total_loss = 0.0
         self.num_samples = 0
@@ -121,6 +121,8 @@ class TrackNetValidatorV3(BaseValidator):
         target_mov = torch.zeros(self.num_groups, 20, 20, 2, device=self.device)
 
         for target_idx, target in enumerate(batch_target):
+            if target_idx >= self.num_groups:
+                break
             if target[1] == 1:
                 # xy
                 grid_x, grid_y, offset_x, offset_y = target_grid(target[2], target[3], self.stride)
@@ -585,6 +587,8 @@ class TrackNetValidator(BaseValidator):
         cls_targets = torch.zeros(self.num_groups, self.cell_num, self.cell_num, 1, device=self.device)
         
         for target_idx, target in enumerate(batch_target):
+            if target_idx >= self.num_groups:
+                break
             grid_x, grid_y, offset_x, offset_y = target_grid(target[2], target[3], self.stride)
             if grid_x >= 80:
                 print(grid_x, grid_y, offset_x, offset_y)
@@ -1145,6 +1149,8 @@ class TrackNetValidatorV2(BaseValidator):
         mask_hit_ball_v2 = torch.zeros(self.num_groups, 1, device=self.device)
 
         for target_idx, target in enumerate(batch_target):
+            if target_idx >= self.num_groups:
+                break
             grid_x, grid_y, offset_x, offset_y = target_grid(target[2], target[3], self.stride)
 
             # 找出快球 => 慢球, 慢球 => 快球
@@ -1641,6 +1647,8 @@ class TrackNetValidatorWithHit(BaseValidator):
         if len(batch_target.shape) == 3:
             batch_target = batch_target[0]
         for idx, target in enumerate(batch_target):
+            if idx >= self.num_groups:
+                break
             if target[1] == 1:
                 # xy
                 grid_x, grid_y, offset_x, offset_y = target_grid(target[2], target[3], stride)

--- a/ultralytics/tracknet/val_dataset.py
+++ b/ultralytics/tracknet/val_dataset.py
@@ -19,6 +19,8 @@ class TrackNetValDataset(Dataset):
     def __init__(self, root_dir, num_input=10, transform=None, prefix=''):
         self.match_mog2 = {}
         self.total_ball = 0
+        if not os.path.isdir(root_dir):
+            raise FileNotFoundError(f"Dataset directory not found: {root_dir}")
         self.root_dir = root_dir
         self.transform = transform
         self.num_input = num_input
@@ -29,9 +31,13 @@ class TrackNetValDataset(Dataset):
 
         image_count = len(glob(os.path.join(self.root_dir, "*/", "frame/", "*/", "*.png")))
 
+        matches = [m.strip('/') for m in glob("*/", root_dir=root_dir) if os.path.isdir(os.path.join(root_dir, m))]
+        if not matches:
+            raise FileNotFoundError(f"No match directories found in {self.root_dir}")
+
         self.pbar = tqdm(total=image_count, miniters=1, smoothing=1)
         # Traverse all matches
-        for match_name in glob("*/", root_dir=root_dir):
+        for match_name in matches:
             match_name = match_name.strip('/')
 
             match_dir_path = os.path.join(root_dir, match_name)
@@ -42,6 +48,11 @@ class TrackNetValDataset(Dataset):
 
             self.read_match(match_name)
         self.pbar.close()
+        if len(self.samples) == 0:
+            raise FileNotFoundError(
+                f'No validation samples found in {self.root_dir}. '
+                'Please verify the dataset files and annotations.'
+            )
 
     def read_match(self, match_name):
         metadata_path = os.path.join(self.root_dir, match_name, 'metadata.json')

--- a/ultralytics/tracknet/val_dataset.py
+++ b/ultralytics/tracknet/val_dataset.py
@@ -131,6 +131,13 @@ class TrackNetValDataset(Dataset):
         if not os.path.isdir(label_dir):
             raise FileNotFoundError(f"Labels directory not found for flat dataset: {label_dir}")
 
+        image_files = sorted(image_files)
+        if len(image_files) < self.num_input:
+            raise FileNotFoundError(
+                f"Flat dataset {self.root_dir} contains {len(image_files)} images, "
+                f"but {self.num_input} are required"
+            )
+
         first = self.open_image(os.path.join(self.root_dir, image_files[0]))
         h, w = first.shape
 

--- a/ultralytics/tracknet/val_dataset.py
+++ b/ultralytics/tracknet/val_dataset.py
@@ -32,8 +32,13 @@ class TrackNetValDataset(Dataset):
         image_count = len(glob(os.path.join(self.root_dir, "*/", "frame/", "*/", "*.png")))
 
         matches = [m.strip('/') for m in glob("*/", root_dir=root_dir) if os.path.isdir(os.path.join(root_dir, m))]
-        flat_images = sorted(glob('*.png', root_dir=root_dir) +
-                            glob('*.jpg', root_dir=root_dir))
+        flat_images = sorted(
+            glob('*.png', root_dir=root_dir) +
+            glob('*.jpg', root_dir=root_dir) +
+            glob('*.jpeg', root_dir=root_dir) +
+            glob('*.PNG', root_dir=root_dir) +
+            glob('*.JPG', root_dir=root_dir) +
+            glob('*.JPEG', root_dir=root_dir))
         if not matches and flat_images:
             self.flat_dataset = True
             self._load_flat_dataset(flat_images)
@@ -224,6 +229,9 @@ class TrackNetValDataset(Dataset):
             frames = [cv2.imread(os.path.join(self.root_dir, match_name, 'frame', video_name, fp), cv2.IMREAD_GRAYSCALE).astype(np.float32)
                       for fp in img_files]
         frames = np.array(frames)  # 轉換為 NumPy 陣列
+
+        if len(frames) == 0:
+            raise FileNotFoundError(f'No images loaded for cache generation: {img_files}')
 
         background_remove = False
 

--- a/ultralytics/tracknet/val_dataset.py
+++ b/ultralytics/tracknet/val_dataset.py
@@ -32,7 +32,8 @@ class TrackNetValDataset(Dataset):
         image_count = len(glob(os.path.join(self.root_dir, "*/", "frame/", "*/", "*.png")))
 
         matches = [m.strip('/') for m in glob("*/", root_dir=root_dir) if os.path.isdir(os.path.join(root_dir, m))]
-        flat_images = sorted(glob(os.path.join(root_dir, '*.png')) + glob(os.path.join(root_dir, '*.jpg')))
+        flat_images = sorted(glob('*.png', root_dir=root_dir) +
+                            glob('*.jpg', root_dir=root_dir))
         if not matches and flat_images:
             self.flat_dataset = True
             self._load_flat_dataset(flat_images)
@@ -136,7 +137,7 @@ class TrackNetValDataset(Dataset):
                         parts = line.strip().split()
                         if parts and int(float(parts[0])) == 0 and len(parts) >= 3:
                             x_norm, y_norm = float(parts[1]), float(parts[2])
-                            vis = 1
+                            vis = int(float(parts[3])) if len(parts) >= 4 else 1
                             break
             X = x_norm * w
             Y = y_norm * h

--- a/ultralytics/tracknet/val_dataset.py
+++ b/ultralytics/tracknet/val_dataset.py
@@ -12,13 +12,15 @@ import torch.nn.functional as F
 from tqdm import tqdm
 from functools import lru_cache
 from glob import glob
+from concurrent.futures import ThreadPoolExecutor
 from ultralytics.tracknet.utils.preprocess import preprocess_csvV4
 from ultralytics.tracknet.utils.preprocess import preprocess_csv
 
 class TrackNetValDataset(Dataset):
-    def __init__(self, root_dir, num_input=10, transform=None, prefix=''):
+    def __init__(self, root_dir, num_input=10, transform=None, prefix='', cache_threads=1):
         self.match_mog2 = {}
         self.total_ball = 0
+        self.cache_threads = max(int(cache_threads), 1)
         if not os.path.isdir(root_dir):
             raise FileNotFoundError(f"Dataset directory not found: {root_dir}")
         self.root_dir = root_dir
@@ -221,13 +223,19 @@ class TrackNetValDataset(Dataset):
     def img_cache(self, match_name, video_name, img_files, npy_path):
         if os.path.isfile(npy_path):
             return
-        # generate cache
-        if getattr(self, 'flat_dataset', False):
-            frames = [cv2.imread(os.path.join(self.root_dir, fp), cv2.IMREAD_GRAYSCALE).astype(np.float32)
-                      for fp in img_files]
+        # generate cache using optional multithreading
+        def read_frame(fp):
+            if getattr(self, 'flat_dataset', False):
+                path = os.path.join(self.root_dir, fp)
+            else:
+                path = os.path.join(self.root_dir, match_name, 'frame', video_name, fp)
+            return cv2.imread(path, cv2.IMREAD_GRAYSCALE).astype(np.float32)
+
+        if self.cache_threads > 1 and len(img_files) > 1:
+            with ThreadPoolExecutor(max_workers=self.cache_threads) as ex:
+                frames = list(ex.map(read_frame, img_files))
         else:
-            frames = [cv2.imread(os.path.join(self.root_dir, match_name, 'frame', video_name, fp), cv2.IMREAD_GRAYSCALE).astype(np.float32)
-                      for fp in img_files]
+            frames = [read_frame(fp) for fp in img_files]
         frames = np.array(frames)  # 轉換為 NumPy 陣列
 
         if len(frames) == 0:
@@ -243,12 +251,17 @@ class TrackNetValDataset(Dataset):
             processed_frames = (frames - median_frame).astype(np.float32)
         else:
             processed_frames = frames
-        images = []
-        for i, processed_frame in enumerate(processed_frames):
-            img = self.pad_to_square(processed_frame)
+        def process_frame(proc_frame):
+            img = self.pad_to_square(proc_frame)
             img = cv2.resize(img, dsize=(640, 640), interpolation=cv2.INTER_CUBIC)
             img = np.expand_dims(img, axis=0)
-            images.append(img)
+            return img
+
+        if self.cache_threads > 1 and len(processed_frames) > 1:
+            with ThreadPoolExecutor(max_workers=self.cache_threads) as ex:
+                images = list(ex.map(process_frame, processed_frames))
+        else:
+            images = [process_frame(f) for f in processed_frames]
         img = np.concatenate(images, 0)
 
         np.save(npy_path, img)

--- a/ultralytics/tracknet/val_dataset.py
+++ b/ultralytics/tracknet/val_dataset.py
@@ -17,12 +17,16 @@ from ultralytics.tracknet.utils.preprocess import preprocess_csvV4
 from ultralytics.tracknet.utils.preprocess import preprocess_csv
 
 class TrackNetValDataset(Dataset):
-    def __init__(self, root_dir, num_input=10, transform=None, prefix='', cache_threads=1):
+    def __init__(self, root_dir, num_input=10, transform=None, prefix='', cache_threads=1, mode='val'):
         self.match_mog2 = {}
         self.total_ball = 0
         self.cache_threads = max(int(cache_threads), 1)
         if not os.path.isdir(root_dir):
-            raise FileNotFoundError(f"Dataset directory not found: {root_dir}")
+            alt = os.path.join(root_dir, 'images', mode)
+            if os.path.isdir(alt):
+                root_dir = alt
+            else:
+                raise FileNotFoundError(f"Dataset directory not found: {root_dir}")
         self.root_dir = root_dir
         self.transform = transform
         self.num_input = num_input

--- a/ultralytics/tracknet/val_dataset.py
+++ b/ultralytics/tracknet/val_dataset.py
@@ -32,6 +32,11 @@ class TrackNetValDataset(Dataset):
         image_count = len(glob(os.path.join(self.root_dir, "*/", "frame/", "*/", "*.png")))
 
         matches = [m.strip('/') for m in glob("*/", root_dir=root_dir) if os.path.isdir(os.path.join(root_dir, m))]
+        flat_images = sorted(glob(os.path.join(root_dir, '*.png')) + glob(os.path.join(root_dir, '*.jpg')))
+        if not matches and flat_images:
+            self.flat_dataset = True
+            self._load_flat_dataset(flat_images)
+            return
         if not matches:
             raise FileNotFoundError(f"No match directories found in {self.root_dir}")
 
@@ -113,6 +118,47 @@ class TrackNetValDataset(Dataset):
 
             self.pbar.update(total_img_len)
 
+    def _load_flat_dataset(self, image_files):
+        label_dir = self.root_dir.replace(os.sep + 'images' + os.sep, os.sep + 'labels' + os.sep)
+        if not os.path.isdir(label_dir):
+            raise FileNotFoundError(f"Labels directory not found for flat dataset: {label_dir}")
+
+        first = self.open_image(os.path.join(self.root_dir, image_files[0]))
+        h, w = first.shape
+
+        records = []
+        for idx, f in enumerate(image_files):
+            label_file = os.path.join(label_dir, os.path.splitext(os.path.basename(f))[0] + '.txt')
+            vis, x_norm, y_norm = 0, 0.0, 0.0
+            if os.path.isfile(label_file):
+                with open(label_file) as lf:
+                    for line in lf:
+                        parts = line.strip().split()
+                        if parts and int(float(parts[0])) == 0 and len(parts) >= 3:
+                            x_norm, y_norm = float(parts[1]), float(parts[2])
+                            vis = 1
+                            break
+            X = x_norm * w
+            Y = y_norm * h
+            records.append([idx, vis, X, Y])
+
+        for i in range(len(records) - 1):
+            dx = -(records[i][2] - records[i + 1][2])
+            dy = -(records[i][3] - records[i + 1][3])
+            records[i].extend([dx, dy])
+        records[-1].extend([0.0, 0.0])
+        for r in records:
+            r.append(0)
+
+        for i in range(len(records) - (self.num_input - 1)):
+            frames = image_files[i:i + self.num_input]
+            target = np.array(records[i:i + self.num_input], dtype=np.float32)
+            target = self.transform_coordinates(target, w, h)
+            npy_path = self.img_cache_dir('flat', 'seq', frames)
+            self.samples.append({'match_name': 'flat', 'video_name': 'seq', 'cache_npy': npy_path,
+                                 'img_files': frames, 'target': target})
+            self.img_cache('flat', 'seq', frames, npy_path)
+
     def img_cache_dir(self, match_name, video_name, img_files):
         s = '|'.join([match_name]+[video_name]+img_files)
         filename = hashlib.sha1(s.encode('utf-8')).hexdigest()
@@ -170,9 +216,12 @@ class TrackNetValDataset(Dataset):
         if os.path.isfile(npy_path):
             return
         # generate cache
-        # 讀取影像並轉換為 `float32`，確保計算精度
-        frames = [cv2.imread(os.path.join(self.root_dir, match_name, 'frame', video_name, fp), cv2.IMREAD_GRAYSCALE).astype(np.float32) 
-                for fp in img_files]
+        if getattr(self, 'flat_dataset', False):
+            frames = [cv2.imread(os.path.join(self.root_dir, fp), cv2.IMREAD_GRAYSCALE).astype(np.float32)
+                      for fp in img_files]
+        else:
+            frames = [cv2.imread(os.path.join(self.root_dir, match_name, 'frame', video_name, fp), cv2.IMREAD_GRAYSCALE).astype(np.float32)
+                      for fp in img_files]
         frames = np.array(frames)  # 轉換為 NumPy 陣列
 
         background_remove = False
@@ -219,7 +268,10 @@ class TrackNetValDataset(Dataset):
         count_ones = (target[:, 1] == 1).sum().item()
         self.total_ball+=count_ones
 
-        img_files = [f"{self.root_dir}/{d['match_name']}/frame/{d['video_name']}/{im}" for im in d['img_files']]
+        if getattr(self, 'flat_dataset', False):
+            img_files = [os.path.join(self.root_dir, im) for im in d['img_files']]
+        else:
+            img_files = [f"{self.root_dir}/{d['match_name']}/frame/{d['video_name']}/{im}" for im in d['img_files']]
 
         return {"img": img, "target": target, "img_files": img_files}
 

--- a/ultralytics/yolo/data/build.py
+++ b/ultralytics/yolo/data/build.py
@@ -93,6 +93,13 @@ def build_yolo_dataset(cfg, img_path, batch, data, mode='train', rect=False, str
 def build_dataloader(dataset, batch, workers, shuffle=True, rank=-1, custom_sampler=None):
     """Return an InfiniteDataLoader or DataLoader for training or validation set."""
     batch = min(batch, len(dataset))
+    if len(dataset) == 0 or batch <= 0:
+        root = getattr(dataset, 'root_dir', getattr(dataset, 'root', getattr(dataset, 'img_path', '')))
+        if root and not os.path.exists(root):
+            raise FileNotFoundError(f'Dataset path not found: {root}')
+        raise ValueError(
+            f'No images found in dataset at {root}. Please check your data paths and annotations.'
+        )
     nd = torch.cuda.device_count()  # number of CUDA devices
     nw = min([os.cpu_count() // max(nd, 1), batch if batch > 1 else 0, workers])  # number of workers
     if custom_sampler is not None:

--- a/ultralytics/yolo/engine/trainer.py
+++ b/ultralytics/yolo/engine/trainer.py
@@ -271,8 +271,9 @@ class BaseTrainer:
 
     def update_sampler_weights(self):
         LOGGER.info("Running per-sample forward pass (batch size=1) to update sampling weights...")
-        # 將模型設定為 eval 模式並關閉梯度
-        self.model.eval()
+        # Run forward passes in training mode so loss computation uses the correct path
+        was_training = self.model.training
+        self.model.train()
         temp_loader = torch.utils.data.DataLoader(
             self.train_loader.dataset,
             batch_size=1,
@@ -347,6 +348,8 @@ class BaseTrainer:
             self.trainset, batch_size=self.batch_size, rank=RANK, mode='train', custom_sampler=new_sampler
         )
         LOGGER.info("DataLoader updated with new weighted sampler based on per-sample losses.")
+        if not was_training:
+            self.model.eval()
 
     def _do_train(self, world_size=1):
         """Train completed, evaluate and plot if specified by arguments."""


### PR DESCRIPTION
## Summary
- raise FileNotFoundError when TrackNet datasets contain no samples
- clarify build_dataloader error with dataset path
- detect missing dataset directories earlier for all TrackNet datasets

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6859905ea7f08323a887d4f082b3ccf2