### PR TITLE
Fix channels mismatch in multi_11ch dataset

### DIFF
--- a/ultralytics/datasets/multi_11ch.yaml
+++ b/ultralytics/datasets/multi_11ch.yaml
@@ -4,6 +4,10 @@ train: images/train
 val: images/val
 test: images/test
 
+# Input configuration
+# The dataset contains 11 grayscale frames stacked as channels.
+in_channels: 11
+
 # Detection classes
 nc: 2
 names:

--- a/ultralytics/tracknet/utils/loss.py
+++ b/ultralytics/tracknet/utils/loss.py
@@ -82,6 +82,8 @@ class TrackNetLossWithHit:
             
             mask_has_ball = torch.zeros_like(target_pos)
             for target_idx, target in enumerate(batch_target[idx]):
+                if target_idx >= self.num_groups:
+                    break
                 if target[6] == 1:
                     grid_x, grid_y, offset_x, offset_y = target_grid(target[2], target[3], stride)
                     hit_targets[target_idx, grid_y, grid_x] = 1
@@ -209,7 +211,7 @@ class TrackNetLoss:
         self.no = m.no
         self.reg_max = m.reg_max
         self.feat_no = m.feat_no
-        self.num_groups = 10
+        self.num_groups = int(getattr(model, 'yaml', {}).get('ch', 10))
         self.device = device
 
         self.use_dfl = m.reg_max > 1
@@ -266,6 +268,8 @@ class TrackNetLoss:
                 stride = self.stride[i]
                 
                 for target_idx, target in enumerate(batch_target[idx]):
+                    if target_idx >= self.num_groups:
+                        break
                     # target xy
                     grid_x, grid_y, offset_x, offset_y = target_grid(target[2], target[3], stride)
                     if grid_x >= 80 or grid_y >= 80:
@@ -406,8 +410,10 @@ class TrackNetLossV5:
         for idx, _ in enumerate(batch_target):
             # pred = [330 * cell_num * cell_num]
             stride = self.stride[0]
-            
+
             for target_idx, target in enumerate(batch_target[idx]):
+                if target_idx >= self.num_groups:
+                    break
                 # target xy
                 grid_x, grid_y, offset_x, offset_y = target_grid(target[2], target[3], stride)
                 # 找出快球 => 慢球, 慢球 => 快球
@@ -576,8 +582,10 @@ class TrackNetLossV4:
         for idx, _ in enumerate(batch_target):
             # pred = [330 * 20 * 20]
             stride = self.stride[0]
-            
+
             for target_idx, target in enumerate(batch_target[idx]):
+                if target_idx >= self.num_groups:
+                    break
                 # target xy
                 grid_x, grid_y, offset_x, offset_y = target_grid(target[2], target[3], stride)
                 # 找出快球 => 慢球, 慢球 => 快球
@@ -744,8 +752,10 @@ class TrackNetLossV3:
         for idx, _ in enumerate(batch_target):
             # pred = [330 * 20 * 20]
             stride = self.stride[0]
-            
+
             for target_idx, target in enumerate(batch_target[idx]):
+                if target_idx >= self.num_groups:
+                    break
                 if target[1] == 1:
                     # xy
                     grid_x, grid_y, offset_x, offset_y = target_grid(target[2], target[3], stride)

--- a/ultralytics/tracknet/val.py
+++ b/ultralytics/tracknet/val.py
@@ -53,7 +53,7 @@ class TrackNetValidatorV3(BaseValidator):
         """Initialize some metrics."""
         # Placeholder for any metrics you might want to use.
         self.stride = 32
-        self.num_groups = 10
+        self.num_groups = int(getattr(model, 'yaml', {}).get('ch', 10))
 
         self.total_loss = 0.0
         self.num_samples = 0
@@ -121,6 +121,8 @@ class TrackNetValidatorV3(BaseValidator):
         target_mov = torch.zeros(self.num_groups, 20, 20, 2, device=self.device)
 
         for target_idx, target in enumerate(batch_target):
+            if target_idx >= self.num_groups:
+                break
             if target[1] == 1:
                 # xy
                 grid_x, grid_y, offset_x, offset_y = target_grid(target[2], target[3], self.stride)
@@ -585,6 +587,8 @@ class TrackNetValidator(BaseValidator):
         cls_targets = torch.zeros(self.num_groups, self.cell_num, self.cell_num, 1, device=self.device)
         
         for target_idx, target in enumerate(batch_target):
+            if target_idx >= self.num_groups:
+                break
             grid_x, grid_y, offset_x, offset_y = target_grid(target[2], target[3], self.stride)
             if grid_x >= 80:
                 print(grid_x, grid_y, offset_x, offset_y)
@@ -1145,6 +1149,8 @@ class TrackNetValidatorV2(BaseValidator):
         mask_hit_ball_v2 = torch.zeros(self.num_groups, 1, device=self.device)
 
         for target_idx, target in enumerate(batch_target):
+            if target_idx >= self.num_groups:
+                break
             grid_x, grid_y, offset_x, offset_y = target_grid(target[2], target[3], self.stride)
 
             # 找出快球 => 慢球, 慢球 => 快球
@@ -1641,6 +1647,8 @@ class TrackNetValidatorWithHit(BaseValidator):
         if len(batch_target.shape) == 3:
             batch_target = batch_target[0]
         for idx, target in enumerate(batch_target):
+            if idx >= self.num_groups:
+                break
             if target[1] == 1:
                 # xy
                 grid_x, grid_y, offset_x, offset_y = target_grid(target[2], target[3], stride)


### PR DESCRIPTION
## Summary
- document that multi_11ch dataset uses 11 grayscale frames
- specify `in_channels: 11` so the TrackNet model builds with the correct input size
- update TrackNet loss and validator to handle variable group counts

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*


------
https://chatgpt.com/codex/tasks/task_e_685e750a5564832384f109e3b76fe406