### PR TITLE
Fix channels mismatch in multi_11ch dataset

### DIFF
--- a/ultralytics/datasets/multi_11ch.yaml
+++ b/ultralytics/datasets/multi_11ch.yaml
@@ -4,6 +4,10 @@ train: images/train
 val: images/val
 test: images/test
 
+# Input configuration
+# The dataset contains 11 grayscale frames stacked as channels.
+in_channels: 11
+
 # Detection classes
 nc: 2
 names:

--- a/ultralytics/tracknet/utils/loss.py
+++ b/ultralytics/tracknet/utils/loss.py
@@ -810,9 +810,13 @@ class FocalLossWithMask(nn.Module):
 
     # OHEM
     def top_k_sampling(self, loss, labels, negative_ratio=3.0):
-        """
-        Hard Negative Mining: Selects the hardest negative examples based on the loss.
-        """
+        """Select the hardest negative samples for focal loss."""
+
+        if loss.ndim == 3:
+            loss = loss[..., 1]
+        if labels.ndim == 3:
+            labels = labels[..., 1]
+
         pos_mask = labels > 0
         num_pos = pos_mask.sum(dim=1, keepdim=True)
         num_neg = negative_ratio * num_pos
@@ -822,11 +826,9 @@ class FocalLossWithMask(nn.Module):
         _, indices = loss_for_sort.sort(dim=1, descending=True)
 
         neg_mask = torch.zeros_like(labels, dtype=torch.bool)
-        for i in range(loss.size(0)):  
+        for i in range(loss.size(0)):
             num_neg_samples = int(num_neg[i].item()) if int(num_neg[i].item()) != 0 else int(negative_ratio)
-            # num_neg_samples = 640
-            # num_neg_samples = int(num_neg[i].item())
-            neg_mask[i, indices[i, :num_neg_samples]] = True 
+            neg_mask[i, indices[i, :num_neg_samples]] = True
 
         return pos_mask | neg_mask
 
@@ -869,7 +871,7 @@ class FocalLossWithMask(nn.Module):
 
         w = (alpha/(1-alpha))
 
-        loss = loss * relevant_mask.float()
+        loss = loss * relevant_mask.unsqueeze(-1).float()
 
         # loss[FN_mask] *= negative_ratio*20*w
         # loss[FP_mask & ~may_has_ball] *= negative_ratio*15*w

--- a/ultralytics/tracknet/utils/loss.py
+++ b/ultralytics/tracknet/utils/loss.py
@@ -82,6 +82,8 @@ class TrackNetLossWithHit:
             
             mask_has_ball = torch.zeros_like(target_pos)
             for target_idx, target in enumerate(batch_target[idx]):
+                if target_idx >= self.num_groups:
+                    break
                 if target[6] == 1:
                     grid_x, grid_y, offset_x, offset_y = target_grid(target[2], target[3], stride)
                     hit_targets[target_idx, grid_y, grid_x] = 1
@@ -209,7 +211,7 @@ class TrackNetLoss:
         self.no = m.no
         self.reg_max = m.reg_max
         self.feat_no = m.feat_no
-        self.num_groups = 10
+        self.num_groups = getattr(model.model[-1], 'num_groups', 10)
         self.device = device
 
         self.use_dfl = m.reg_max > 1
@@ -266,6 +268,8 @@ class TrackNetLoss:
                 stride = self.stride[i]
                 
                 for target_idx, target in enumerate(batch_target[idx]):
+                    if target_idx >= self.num_groups:
+                        break
                     # target xy
                     grid_x, grid_y, offset_x, offset_y = target_grid(target[2], target[3], stride)
                     if grid_x >= 80 or grid_y >= 80:
@@ -406,8 +410,10 @@ class TrackNetLossV5:
         for idx, _ in enumerate(batch_target):
             # pred = [330 * cell_num * cell_num]
             stride = self.stride[0]
-            
+
             for target_idx, target in enumerate(batch_target[idx]):
+                if target_idx >= self.num_groups:
+                    break
                 # target xy
                 grid_x, grid_y, offset_x, offset_y = target_grid(target[2], target[3], stride)
                 # 找出快球 => 慢球, 慢球 => 快球
@@ -576,8 +582,10 @@ class TrackNetLossV4:
         for idx, _ in enumerate(batch_target):
             # pred = [330 * 20 * 20]
             stride = self.stride[0]
-            
+
             for target_idx, target in enumerate(batch_target[idx]):
+                if target_idx >= self.num_groups:
+                    break
                 # target xy
                 grid_x, grid_y, offset_x, offset_y = target_grid(target[2], target[3], stride)
                 # 找出快球 => 慢球, 慢球 => 快球
@@ -744,8 +752,10 @@ class TrackNetLossV3:
         for idx, _ in enumerate(batch_target):
             # pred = [330 * 20 * 20]
             stride = self.stride[0]
-            
+
             for target_idx, target in enumerate(batch_target[idx]):
+                if target_idx >= self.num_groups:
+                    break
                 if target[1] == 1:
                     # xy
                     grid_x, grid_y, offset_x, offset_y = target_grid(target[2], target[3], stride)

--- a/ultralytics/tracknet/utils/loss.py
+++ b/ultralytics/tracknet/utils/loss.py
@@ -832,6 +832,10 @@ class FocalLossWithMask(nn.Module):
 
     def forward(self, pred, label, gamma=2, alpha=0.75, negative_ratio=3.0):
         """Calculates and updates confusion matrix for object detection/classification tasks."""
+        # If label is (B, N, 1) but pred is (B, N, 2), expand label to one-hot
+        if label.shape[-1] == 1 and pred.shape[-1] == 2:
+            label = torch.cat([1 - label, label], dim=-1)
+
         assert torch.all((label == 0) | (label == 1)), f"`label` contains invalid values: {label.unique()}"
         loss = F.binary_cross_entropy_with_logits(pred, label, reduction='none')
         assert (loss >= 0).all(), f"`loss` contains negative values. Min: {loss.min()}, Max: {loss.max()}"

--- a/ultralytics/tracknet/val.py
+++ b/ultralytics/tracknet/val.py
@@ -53,7 +53,7 @@ class TrackNetValidatorV3(BaseValidator):
         """Initialize some metrics."""
         # Placeholder for any metrics you might want to use.
         self.stride = 32
-        self.num_groups = 10
+        self.num_groups = getattr(model.model[-1], 'num_groups', 10)
 
         self.total_loss = 0.0
         self.num_samples = 0
@@ -121,6 +121,8 @@ class TrackNetValidatorV3(BaseValidator):
         target_mov = torch.zeros(self.num_groups, 20, 20, 2, device=self.device)
 
         for target_idx, target in enumerate(batch_target):
+            if target_idx >= self.num_groups:
+                break
             if target[1] == 1:
                 # xy
                 grid_x, grid_y, offset_x, offset_y = target_grid(target[2], target[3], self.stride)
@@ -585,6 +587,8 @@ class TrackNetValidator(BaseValidator):
         cls_targets = torch.zeros(self.num_groups, self.cell_num, self.cell_num, 1, device=self.device)
         
         for target_idx, target in enumerate(batch_target):
+            if target_idx >= self.num_groups:
+                break
             grid_x, grid_y, offset_x, offset_y = target_grid(target[2], target[3], self.stride)
             if grid_x >= 80:
                 print(grid_x, grid_y, offset_x, offset_y)
@@ -1145,6 +1149,8 @@ class TrackNetValidatorV2(BaseValidator):
         mask_hit_ball_v2 = torch.zeros(self.num_groups, 1, device=self.device)
 
         for target_idx, target in enumerate(batch_target):
+            if target_idx >= self.num_groups:
+                break
             grid_x, grid_y, offset_x, offset_y = target_grid(target[2], target[3], self.stride)
 
             # 找出快球 => 慢球, 慢球 => 快球
@@ -1641,6 +1647,8 @@ class TrackNetValidatorWithHit(BaseValidator):
         if len(batch_target.shape) == 3:
             batch_target = batch_target[0]
         for idx, target in enumerate(batch_target):
+            if idx >= self.num_groups:
+                break
             if target[1] == 1:
                 # xy
                 grid_x, grid_y, offset_x, offset_y = target_grid(target[2], target[3], stride)


### PR DESCRIPTION
## Summary
- document that multi_11ch dataset uses 11 grayscale frames
- specify `in_channels: 11` so the TrackNet model builds with the correct input size
- update TrackNet loss and validator to handle variable group counts

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_685e750a5564832384f109e3b76fe406