### PR TITLE
Fix mismatched tensor sizes in Pose head

### DIFF
--- a/ultralytics/nn/modules/head.py
+++ b/ultralytics/nn/modules/head.py
@@ -371,7 +371,11 @@ class Pose(Detect):
         self.detect = Detect.forward
 
         c4 = max(ch[0] // 4, self.nk)
-        self.cv4 = nn.ModuleList(nn.Sequential(Conv(x, c4, 3), Conv(c4, c4, 3), nn.Conv2d(c4, self.nk, 1)) for x in ch)
+        # match detection head which predicts `num_groups` sets of outputs per cell
+        self.cv4 = nn.ModuleList(
+            nn.Sequential(Conv(x, c4, 3), Conv(c4, c4, 3), nn.Conv2d(c4, self.nk * self.num_groups, 1))
+            for x in ch
+        )
 
     def forward(self, x):
         """Perform forward pass through YOLO model and return predictions."""


### PR DESCRIPTION
## Summary
- align Pose keypoint head with detection groups

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_685fe11aaf2c83239ce991a1f47d58f4