### PR TITLE
Add multi-task dataset utilities

### DIFF
--- a/loader_factory.py
+++ b/loader_factory.py
@@ -1,0 +1,53 @@
+"""DataLoader factory for multi-task TrackNet + Pose training."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict
+
+from torch.utils.data import DataLoader
+
+from ultralytics.tracknet.dataset import TrackNetDataset
+
+from multi_dataset import MultiDatasetWrapper, collate_fn
+
+__all__ = ["build_multi_loader"]
+
+
+def build_multi_loader(cfg: Dict) -> Dict[str, DataLoader]:
+    """Build training and validation dataloaders from a config dictionary."""
+    datasets_cfg = cfg.get("datasets", {})
+    track_cfg = datasets_cfg.get("track", {})
+    pose_cfg = datasets_cfg.get("pose", {})
+
+    img_size = cfg.get("img_size", 640)
+    batch_size = cfg.get("batch_size", 32)
+    num_workers = cfg.get("num_workers", 8)
+
+    track_root = track_cfg.get("root")
+    pose_root = pose_cfg.get("label_root", track_root)
+    frame_indices = tuple(pose_cfg.get("frame_indices", (1, 6)))
+
+    track_train = TrackNetDataset(root_dir=track_root, prefix="train")
+    track_val = TrackNetDataset(root_dir=track_root, prefix="val")
+
+    train_ds = MultiDatasetWrapper(track_train, pose_root, frame_indices, img_size)
+    val_ds = MultiDatasetWrapper(track_val, pose_root, frame_indices, img_size)
+
+    train_loader = DataLoader(
+        train_ds,
+        batch_size=batch_size,
+        shuffle=True,
+        num_workers=num_workers,
+        collate_fn=collate_fn,
+    )
+    val_loader = DataLoader(
+        val_ds,
+        batch_size=batch_size,
+        shuffle=False,
+        num_workers=num_workers,
+        collate_fn=collate_fn,
+    )
+
+    return {"train": train_loader, "val": val_loader}
+

--- a/multi_dataset.py
+++ b/multi_dataset.py
@@ -1,0 +1,140 @@
+"""Wrapper dataset to combine TrackNet and pose data."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable, Dict, List, Tuple
+
+import cv2
+import torch
+from torch.utils.data import Dataset, default_collate
+
+from ultralytics.tracknet.dataset import TrackNetDataset
+
+__all__ = ["MultiDatasetWrapper", "collate_fn"]
+
+
+class MultiDatasetWrapper(Dataset):
+    """Combine :class:`TrackNetDataset` samples with pose annotations."""
+
+    def __init__(
+        self,
+        track_ds: TrackNetDataset,
+        pose_label_root: str | Path,
+        pose_frame_indices: Tuple[int, int] = (1, 6),
+        img_size: int = 640,
+        transforms: Callable | None = None,
+    ) -> None:
+        self.track_ds = track_ds
+        self.pose_root = Path(pose_label_root)
+        self.pose_frame_indices = pose_frame_indices
+        self.img_size = img_size
+        self.transforms = transforms
+
+    def __len__(self) -> int:
+        return len(self.track_ds)
+
+    @staticmethod
+    def _pad_resize(img: torch.Tensor, size: int) -> torch.Tensor:
+        h, w = img.shape
+        max_dim = max(h, w)
+        pad_diff = max_dim - min(h, w)
+        pad1, pad2 = pad_diff // 2, pad_diff - pad_diff // 2
+        if h < w:
+            pad = (0, 0, pad1, pad2)
+        else:
+            pad = (pad1, pad2, 0, 0)
+        img = cv2.copyMakeBorder(img, *pad, borderType=cv2.BORDER_CONSTANT, value=0)
+        img = cv2.resize(img, (size, size), interpolation=cv2.INTER_CUBIC)
+        return torch.from_numpy(img).unsqueeze(0).float() / 255.0
+
+    def _load_pose(self, match: str, video: str, frame: str) -> Dict[str, torch.Tensor]:
+        img_path = self.pose_root / match / "frame" / video / frame
+        label_path = self.pose_root / match / "pose_label" / video / Path(frame).with_suffix(".txt")
+        img = cv2.imread(str(img_path), cv2.IMREAD_GRAYSCALE)
+        h, w = img.shape
+        img_tensor = self._pad_resize(img, self.img_size)
+
+        boxes: List[torch.Tensor] = []
+        kpts: List[torch.Tensor] = []
+        clses: List[int] = []
+        if label_path.is_file():
+            with open(label_path) as f:
+                lines = [x.strip() for x in f.readlines() if x.strip()]
+            for line in lines:
+                vals = [float(v) for v in line.split()]
+                clses.append(int(vals[0]))
+                bbox = torch.tensor(vals[1:5], dtype=torch.float32)
+                keypoints = torch.tensor(vals[5:], dtype=torch.float32).view(17, 3)
+                bbox[:2] *= torch.tensor([w, h])
+                bbox[2:] *= torch.tensor([w, h])
+                keypoints[:, 0] *= w
+                keypoints[:, 1] *= h
+                max_dim = max(w, h)
+                pad = (max_dim - min(w, h)) // 2
+                if h < w:
+                    bbox[1] += pad
+                    keypoints[:, 1] += pad
+                else:
+                    bbox[0] += pad
+                    keypoints[:, 0] += pad
+                scale = self.img_size / max_dim
+                bbox *= scale
+                keypoints[:, :2] *= scale
+                bbox /= self.img_size
+                keypoints[:, :2] /= self.img_size
+                boxes.append(bbox)
+                kpts.append(keypoints)
+        target_boxes = torch.stack(boxes, 0) if boxes else torch.zeros((0, 4))
+        target_kpts = torch.stack(kpts, 0) if kpts else torch.zeros((0, 17, 3))
+        target_cls = torch.tensor(clses, dtype=torch.int64)
+        return {"img": img_tensor, "boxes": target_boxes, "keypoints": target_kpts, "cls": target_cls}
+
+    def __getitem__(self, idx: int) -> Dict:
+        track_sample = self.track_ds[idx]
+        meta = self.track_ds.samples[idx]
+        match = meta["match_name"]
+        video = meta["video_name"]
+
+        imgs = []
+        boxes_list = []
+        kpts_list = []
+        cls_list = []
+        for i in self.pose_frame_indices:
+            frame = meta["img_files"][i]
+            pose = self._load_pose(match, video, frame)
+            imgs.append(pose["img"])
+            boxes_list.append(pose["boxes"])
+            kpts_list.append(pose["keypoints"])
+            cls_list.append(pose["cls"])
+
+        pose_dict = {
+            "imgs": torch.stack(imgs, 0),
+            "targets": {
+                "frame_idxs": torch.tensor(self.pose_frame_indices, dtype=torch.long),
+                "boxes": boxes_list,
+                "keypoints": kpts_list,
+                "cls": cls_list,
+            },
+        }
+        return {"track": track_sample, "pose": pose_dict}
+
+
+def collate_fn(batch: List[Dict]) -> Dict:
+    track_batch = default_collate([b["track"] for b in batch])
+    pose_imgs = torch.stack([b["pose"]["imgs"] for b in batch], 0)
+    frame_idxs = default_collate([b["pose"]["targets"]["frame_idxs"] for b in batch])
+    boxes = [b["pose"]["targets"]["boxes"] for b in batch]
+    keypoints = [b["pose"]["targets"]["keypoints"] for b in batch]
+    cls = [b["pose"]["targets"]["cls"] for b in batch]
+    pose_batch = {
+        "imgs": pose_imgs,
+        "targets": {
+            "frame_idxs": frame_idxs,
+            "boxes": boxes,
+            "keypoints": keypoints,
+            "cls": cls,
+        },
+    }
+    return {"track": track_batch, "pose": pose_batch}
+

--- a/pose_dataset.py
+++ b/pose_dataset.py
@@ -1,0 +1,99 @@
+"""Pose dataset for single grayscale image and keypoint label.
+
+This module provides :class:`PoseDataset` used to read a single grayscale frame
+and its associated YOLOv8 style pose label. Images are padded to square, resized
+and converted to ``torch.Tensor`` in ``[0, 1]`` range. Bounding boxes and
+keypoints are returned in normalized ``cxcywh``/``xyv`` format.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Sequence
+
+import cv2
+import torch
+from torch.utils.data import Dataset
+
+__all__ = ["PoseDataset"]
+
+
+class PoseDataset(Dataset):
+    """Dataset that loads a single image and its pose annotation."""
+
+    def __init__(self, image_paths: Sequence[str | Path], img_size: int = 640) -> None:
+        self.image_paths: List[Path] = [Path(p) for p in image_paths]
+        self.img_size = img_size
+
+    def __len__(self) -> int:  # pragma: no cover - thin wrapper
+        return len(self.image_paths)
+
+    def _pad_resize(self, img: torch.Tensor) -> torch.Tensor:
+        h, w = img.shape
+        max_dim = max(h, w)
+        pad_diff = max_dim - min(h, w)
+        pad1, pad2 = pad_diff // 2, pad_diff - pad_diff // 2
+        if h < w:
+            pad = (0, 0, pad1, pad2)
+        else:
+            pad = (pad1, pad2, 0, 0)
+        img = cv2.copyMakeBorder(img, *pad, borderType=cv2.BORDER_CONSTANT, value=0)
+        img = cv2.resize(img, (self.img_size, self.img_size), interpolation=cv2.INTER_CUBIC)
+        return torch.from_numpy(img).unsqueeze(0).float() / 255.0
+
+    def _transform_coords(self, coords: torch.Tensor, img_w: int, img_h: int) -> torch.Tensor:
+        max_dim = max(img_w, img_h)
+        pad_diff = max_dim - min(img_w, img_h)
+        pad = pad_diff // 2
+        if img_h < img_w:
+            coords[:, 1] += pad
+        else:
+            coords[:, 0] += pad
+        scale = self.img_size / max_dim
+        coords[:, :2] *= scale
+        coords /= self.img_size
+        return coords
+
+    def __getitem__(self, idx: int) -> dict:
+        img_path = self.image_paths[idx]
+        label_path = img_path.with_suffix(".txt")
+        img = cv2.imread(str(img_path), cv2.IMREAD_GRAYSCALE)
+        h, w = img.shape
+        tensor_img = self._pad_resize(img)
+
+        boxes: List[torch.Tensor] = []
+        keypoints: List[torch.Tensor] = []
+        classes: List[int] = []
+
+        if label_path.is_file():
+            with open(label_path, "r") as f:
+                lines = [x.strip() for x in f.readlines() if x.strip()]
+            for line in lines:
+                vals = [float(v) for v in line.split()]
+                cls = int(vals[0])
+                bbox = torch.tensor(vals[1:5], dtype=torch.float32)
+                kps = torch.tensor(vals[5:], dtype=torch.float32).view(17, 3)
+                # convert to pixel coords
+                bbox[:2] *= torch.tensor([w, h])
+                bbox[2:] *= torch.tensor([w, h])
+                kps[:, 0] *= w
+                kps[:, 1] *= h
+                bbox = self._transform_coords(bbox.view(1, 4), w, h).squeeze(0)
+                kps[:, :2] = self._transform_coords(kps[:, :2], w, h)
+                boxes.append(bbox)
+                keypoints.append(kps)
+                classes.append(cls)
+
+        target_boxes = torch.stack(boxes, 0) if boxes else torch.zeros((0, 4))
+        target_kpts = torch.stack(keypoints, 0) if keypoints else torch.zeros((0, 17, 3))
+        target_cls = torch.tensor(classes, dtype=torch.int64)
+
+        return {
+            "img": tensor_img,
+            "boxes": target_boxes,
+            "keypoints": target_kpts,
+            "cls": target_cls,
+            "frame_idx": int(img_path.stem),
+            "img_path": img_path,
+        }
+


### PR DESCRIPTION
## Summary
- implement `PoseDataset` for grayscale images with pose labels
- add `MultiDatasetWrapper` with custom `collate_fn`
- create `build_multi_loader` helper for TrackNet and pose dataloaders

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_686cd1af41b08323b9d88ffa229169fb